### PR TITLE
Change to new trilinos version

### DIFF
--- a/do-configure
+++ b/do-configure
@@ -3,7 +3,7 @@
 SOURCE_DIRECTORY="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 BUILD_DIRECTORY=`pwd`
 
-Trilinos_DIR="/imcs/public/compsim/lib/Q4_2019_ubuntu20/TPL/trilinos-build-release/lib/cmake/Trilinos"
+Trilinos_DIR="/imcs/public/compsim/lib/Q4_2019_ubuntu20/TPL/trilinos-build-release_parmetis4/lib/cmake/Trilinos"
 
 echo "Source and build directory:"
 echo "-- Path to source code:    " $SOURCE_DIRECTORY


### PR DESCRIPTION
This MR changes the do-configure to use the new `Q4_2019` Trilinos build linked to Parmetis 4.0.3. at the IMCS.

To use this do-configure, you'll need access to the new version first. So, let's hold off on merging this until next week.