### PR TITLE
Adapt wording from GitLab to GitHub

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,9 @@
 <!--
-Provide a general summary of your changes in the Title above. Use the prefix "WIP:" or "Draft:" if this is a work-in-progress merge request.
+Provide a general summary of your changes in the Title above. Use the prefix "WIP:" or "Draft:" if this is a work-in-progress pull request.
 -->
 
 <!--
-Note that anything between these delimiters is a comment that will not appear in the merge request description once created.
+Note that anything between these delimiters is a comment that will not appear in the pull request description once created.
 -->
 
 <!--
@@ -14,18 +14,14 @@ Assignees: Assign yourself.
 Reviewer: Assign a developer who is qualified to review your changes. 
 -->
 
-<!--
-Check the box "Delete source branch when merge request is accepted." when opening the merge request in order to automatically delete the feature branch from GitLab after it has been merged.  Note that this will just remove the feature branch from GitLab, but not from your local clone of the repository.
--->
-
 ## Description and Context
 <!--
 Provide a brief and concise description of your proposed change. Why is this change required? What problem does it solve?
 -->
 
-## Related Issues and Merge Requests
+## Related Issues and Pull Requests
 <!--
-If applicable, let us know how this merge request is related to any other open issues or merge requests:
+If applicable, let us know how this pull request is related to any other open issues or pull requests:
 -->
 * Closes
 * Blocks
@@ -45,16 +41,16 @@ Feel free to provide further information if useful or necessary.
 <!--
 Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, please ask; we are here to help.
 -->
-- [ ] My commit messages mention the appropriate GitLab issue numbers and are longer than one line where appropriate.
+- [ ] My commit messages mention the appropriate GitHub issue numbers and are longer than one line where appropriate.
 - [ ] I have added/updated documentation where necessary.
 
 ## Additional Information
 <!--
-Is there anything else your fellow developers need to know in evaluating this merge request?
+Is there anything else your fellow developers need to know in evaluating this pull request?
 Feel free to add supplementary material here (e.g. screen output, log files, screenshots)
 -->
 
 ## Interested Parties / Possible Reviewers
 <!--
-If there's any developer, who you think should be looped in on this merge request, feel free to @mention them here.
+If there's any developer, who you think should be looped in on this pull request, feel free to @mention them here.
 -->


### PR DESCRIPTION
## Description and Context

Replace GitLab-specific wording with GitHub terms.

## Related Issues and Merge Requests

* Part of #26 

## How Has This Been Tested?

I inspected the rendered markdown file locally on my machine.

## Checklist

- [x] My commit messages mention the appropriate GitLab issue numbers and are longer than one line where appropriate.
- [ ] I have added/updated documentation where necessary.

## Additional Information
<!--
Is there anything else your fellow developers need to know in evaluating this merge request?
Feel free to add supplementary material here (e.g. screen output, log files, screenshots)
-->

## Interested Parties / Possible Reviewers

@RShaw026 @NoraHagmeyer 