### PR TITLE
Treat Trilinos as SYSTEM lib to ignore warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,8 @@ endif()
 
 # Specify include directories in this repository and for Trilinos
 include_directories(".")
-include_directories(${Trilinos_TPL_INCLUDE_DIRS})
-include_directories(${Trilinos_INCLUDE_DIRS})
+include_directories(SYSTEM ${Trilinos_TPL_INCLUDE_DIRS})
+include_directories(SYSTEM ${Trilinos_INCLUDE_DIRS})
 
 # Add to the library path Trilinos' library path, and the library
 # paths of the third-party libraries (TPLs) with which Trilinos was


### PR DESCRIPTION
## Description and Context

`MIRCO` has no influence on the warnings or warning-free state of its
external dependency `Trilinos`. By telling `CMake` to treat `Trilinos` as a
`SYSTEM` library, compiling `MIRCO` will ignore `Trilinos`-internal warnings.

Idea is taken from https://stackoverflow.com/questions/1867065/how-to-suppress-gcc-warnings-from-library-headers. I have double-checked with Baci. It follows the exact same approach.

## Related Issues and Pull Requests

* Follows PR #34
* Related to #23

## How Has This Been Tested?

I configured into a clean build directory and then was able to build warning free.

<details><summary>Build log</summary>

```
make -j 13
Scanning dependencies of target gtest
Scanning dependencies of target mirco_utils
Scanning dependencies of target mirco_io
Scanning dependencies of target mirco_library
[  3%] Building CXX object CMakeFiles/mirco_utils.dir/src/filesystem_utils.cpp.o
[ 11%] Building CXX object CMakeFiles/mirco_library.dir/src/topology.cpp.o
[ 15%] Building CXX object CMakeFiles/mirco_library.dir/src/warmstart.cpp.o
[ 15%] Building CXX object CMakeFiles/mirco_library.dir/src/linearsolver.cpp.o
[ 19%] Building CXX object CMakeFiles/mirco_library.dir/src/evaluate.cpp.o
[ 23%] Building CXX object CMakeFiles/mirco_library.dir/src/topologyfactory.cpp.o
[ 26%] Building CXX object CMakeFiles/mirco_library.dir/src/nonlinearsolver.cpp.o
[ 30%] Building CXX object CMakeFiles/mirco_library.dir/src/matrixsetup.cpp.o
[ 34%] Building CXX object CMakeFiles/mirco_io.dir/src/writetofile.cpp.o
[ 38%] Building CXX object CMakeFiles/mirco_io.dir/src/setparameters.cpp.o
[ 42%] Building CXX object extern/googletest/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
[ 46%] Linking CXX static library libmirco_utils.a
[ 46%] Built target mirco_utils
[ 50%] Linking CXX static library libmirco_library.a
[ 50%] Built target mirco_library
[ 53%] Linking CXX static library libmirco_io.a
[ 53%] Built target mirco_io
[ 57%] Linking CXX static library ../../../lib/libgtest.a
[ 57%] Built target gtest
Scanning dependencies of target tests
Scanning dependencies of target gtest_main
Scanning dependencies of target mirco
Scanning dependencies of target gmock
[ 61%] Building CXX object CMakeFiles/mirco.dir/src/main.cpp.o
[ 65%] Building CXX object extern/googletest/googletest/CMakeFiles/gtest_main.dir/src/gtest_main.cc.o
[ 69%] Building CXX object CMakeFiles/tests.dir/tests/unittests/test.cpp.o
[ 73%] Building CXX object CMakeFiles/tests.dir/tests/unittests/nonlinear_solver_test.cpp.o
[ 76%] Building CXX object extern/googletest/googlemock/CMakeFiles/gmock.dir/src/gmock-all.cc.o
[ 80%] Linking CXX executable mirco
[ 84%] Linking CXX static library ../../../lib/libgtest_main.a
[ 84%] Built target gtest_main
[ 88%] Linking CXX executable tests
[ 88%] Built target mirco
[ 88%] Built target tests
[ 92%] Linking CXX static library ../../../lib/libgmock.a
[ 92%] Built target gmock
Scanning dependencies of target gmock_main
[ 96%] Building CXX object extern/googletest/googlemock/CMakeFiles/gmock_main.dir/src/gmock_main.cc.o
[100%] Linking CXX static library ../../../lib/libgmock_main.a
[100%] Built target gmock_main
```
</details>

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers and are longer than one line where appropriate.
- [ ] I have added/updated documentation where necessary.

## Additional Information
<!--
Is there anything else your fellow developers need to know in evaluating this pull request?
Feel free to add supplementary material here (e.g. screen output, log files, screenshots)
-->

## Interested Parties / Possible Reviewers
@NoraHagmeyer @RShaw026 