### PR TITLE
Remove JSON artefacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,11 +49,6 @@ include_directories(SYSTEM ${Trilinos_INCLUDE_DIRS})
 link_directories(${Trilinos_TPL_LIBRARY_DIRS})
 link_directories(${Trilinos_LIBRARY_DIRS})
 
-#find JsonCpp package
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(JSONCPP jsoncpp)
-link_libraries(${JSONCPP_LIBRARIES})
-
 # Compile mirco library
 add_library(mirco_library
   src/topology.cpp
@@ -91,7 +86,6 @@ target_link_libraries(mirco
   mirco_library
   mirco_io
   mirco_utils
-  ${JSONCPP_LIBRARIES}
   ${Trilinos_LIBRARIES}
   ${Trilinos_TPL_LIBRARIES}
   ${MPI_LIBRARIES}
@@ -112,7 +106,6 @@ target_link_libraries(tests
   mirco_io
   mirco_utils
   gtest
-  ${JSONCPP_LIBRARIES}
   ${Trilinos_LIBRARIES}
   ${Trilinos_TPL_LIBRARIES}
   ${MPI_LIBRARIES}


### PR DESCRIPTION
## Description and Context

PR #34 has removed support for JSON input, yet it didn't properly clean `CMakeLists.txt`. This PR now removes the remaining JSON artefacts in `CMakeLists.txt`.

Minor: unify formatting of some comments in `CMakeLists.txt`.

## Related Issues and Pull Requests

* Follows #18, PR #34

## How Has This Been Tested?

Configure and build from scratch ✅ 

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers and are longer than one line where appropriate.
- [ ] I have added/updated documentation where necessary.

<!--
## Additional Information
Is there anything else your fellow developers need to know in evaluating this pull request?
Feel free to add supplementary material here (e.g. screen output, log files, screenshots)
-->

## Interested Parties / Possible Reviewers

@RShaw026 @NoraHagmeyer 