### PR TITLE
Add version numbering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 # Project name
-project(mirco)
+project(mirco VERSION 0.1.0)
 
 # Check for out-of-source build
 if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
## Description and Context

Add support for semantic version numbering as proposed at www.semver.org.

The version number will help to clearly identify a given version of the code, e.g. for interfering with other codes or for publications.

## Related Issues and Pull Requests

* Closes #62 

## How Has This Been Tested?

- When configuring locally, the version number and its individual components are written to `CMakeCache.txt`.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers and are longer than one line where appropriate.
- [ ] I have added/updated documentation where necessary.

<!--
## Additional Information

Is there anything else your fellow developers need to know in evaluating this pull request?
Feel free to add supplementary material here (e.g. screen output, log files, screenshots)
-->

## Interested Parties / Possible Reviewers

@RShaw026 @NoraHagmeyer 