### PR TITLE
Fix build warning by removing unused variable

### DIFF
--- a/src/mirco_evaluate.cpp
+++ b/src/mirco_evaluate.cpp
@@ -123,9 +123,8 @@ void MIRCO::Evaluate(double& pressure, double Delta, double LateralLength, doubl
       "The solution did not converge in the maximum number of iternations defined");
   // @{
 
-  // Calculate the final force and area value at the end of the iteration.
+  // Calculate the final force value at the end of the iteration.
   const double force = force0[k - 1];
-  const double area = area0[k - 1];
 
   // Mean pressure
   double sigmaz = force / pow(LateralLength, 2);


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above. Use the prefix "WIP:" or "Draft:" if this is a work-in-progress pull request.
-->

<!--
Note that anything between these delimiters is a comment that will not appear in the pull request description once created.
-->

<!--
Assignees: Assign yourself.
-->

<!--
Reviewer: Assign a developer who is qualified to review your changes. 
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Why is this change required? What problem does it solve?
-->

Earlier, build warning was issued, leading to pipeline build fail in BACI when integrated with MIRCO. In this PR, the unused variable is removed to fix the warning. 
The unused variable is the calculation of area, which is not required now, and will be added later when required.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests:
-->
* Closes
* Blocks
* Is blocked by
* Follows
* Precedes
* Related to
* Part of
* Composed of

## How Has This Been Tested?
<!--
Feel free to provide further information if useful or necessary.
-->
No warnings while building the code. All the tests are passing.

## Checklist
<!--
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, please ask; we are here to help.
-->
- [ ] My commit messages mention the appropriate GitHub issue numbers and are longer than one line where appropriate.
- [ ] I have added/updated documentation where necessary.

## Additional Information
<!--
Is there anything else your fellow developers need to know in evaluating this pull request?
Feel free to add supplementary material here (e.g. screen output, log files, screenshots)
-->

## Interested Parties / Possible Reviewers
<!--
If there's any developer, who you think should be looped in on this pull request, feel free to @mention them here.
-->
@mayrmt @maxfirmbach 