### PR TITLE
Add OpenMP dependency in the config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,13 +127,24 @@ target_link_libraries(mirco PUBLIC mirco::mirco_lib)
 
 # Install mirco (to be used as a library by other codes)
 install(TARGETS mirco_lib mirco_core mirco_io mirco_utils _Trilinos_all_selected_libs
-  EXPORT mirco_libConfig
+  EXPORT mirco_libTargets
   ARCHIVE LIBRARY PUBLIC_HEADER
   )
 
-install(EXPORT mirco_libConfig
+install(EXPORT mirco_libTargets
   NAMESPACE mirco::
   DESTINATION lib/cmake/mirco
+  )
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(cmake/mirco_libConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/mirco_libConfig.cmake
+  INSTALL_DESTINATION lib/cmake/mirco
+  )
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/mirco_libConfig.cmake
+  DESTINATION lib/cmake/mirco 
   )
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/ DESTINATION include/mirco FILES_MATCHING PATTERN "*.h*")
@@ -156,4 +167,3 @@ if(GTEST_IN_MIRCO)
 
   include(TestingFramework.cmake)
 endif()
-

--- a/cmake/mirco_libConfig.cmake.in
+++ b/cmake/mirco_libConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+find_package(OpenMP QUIET)
+
+include("${CMAKE_CURRENT_LIST_DIR}/mirco_libTargets.cmake")


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above. Use the prefix "WIP:" or "Draft:" if this is a work-in-progress pull request.
-->

<!--
Note that anything between these delimiters is a comment that will not appear in the pull request description once created.
-->

<!--
Assignees: Assign yourself.
-->

<!--
Reviewer: Assign a developer who is qualified to review your changes. 
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Why is this change required? What problem does it solve?
-->

This MR adds the OpenMP dependency in the `mirco_libConfig.cmake` file. Therefore, BACI does not need to do `find_package(OpenMP)`.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests:
-->
* Closes
* Blocks
* Is blocked by
* Follows PR #79 
* Precedes
* Related to
* Part of
* Composed of

## How Has This Been Tested?
<!--
Feel free to provide further information if useful or necessary.
-->
Compiled together with BACI in my local machine.

## Checklist
<!--
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, please ask; we are here to help.
-->
- [ ] My commit messages mention the appropriate GitHub issue numbers and are longer than one line where appropriate.
- [ ] I have added/updated documentation where necessary.

## Additional Information
<!--
Is there anything else your fellow developers need to know in evaluating this pull request?
Feel free to add supplementary material here (e.g. screen output, log files, screenshots)
-->

## Interested Parties / Possible Reviewers
<!--
If there's any developer, who you think should be looped in on this pull request, feel free to @mention them here.
-->
@mayrmt 