### PR TITLE
Do not search for MPI with warnings enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,6 @@ endif()
 
 set(CMAKE_CXX_STANDARD 17)
 
-# Compiler flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -O3")
-
 # Add libraries
 if(GTEST_IN_MIRCO)
   add_subdirectory("extern/googletest")
@@ -81,6 +78,10 @@ find_package(OpenMP REQUIRED)
 
 # Find OpenMPI
 find_package(MPI REQUIRED)
+
+# Compiler flags: delay this modification after MPI was found. Otherwise,
+# trying to compile with MPI can give warnings.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -O3")
 
 # Compile mirco library
 add_library(mirco_core


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above. Use the prefix "WIP:" or "Draft:" if this is a work-in-progress pull request.
-->

<!--
Note that anything between these delimiters is a comment that will not appear in the pull request description once created.
-->

<!--
Assignees: Assign yourself.
-->

<!--
Reviewer: Assign a developer who is qualified to review your changes. 
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Why is this change required? What problem does it solve?
-->

When finding MPI with `-Wextra` on, a warning is reported in some deprecated CXX bindings. Avoid this by moving the modification of `CMAKE_CXX_FLAGS`  behind the find_package() call. This avoids issues when users set `-Werror` in their `CMAKE_CXX_FLAGS` variable.


## How Has This Been Tested?
<!--
Feel free to provide further information if useful or necessary.
-->

Local build.

## Checklist
<!--
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, please ask; we are here to help.
-->
- [ ] My commit messages mention the appropriate GitHub issue numbers and are longer than one line where appropriate.
- [ ] I have added/updated documentation where necessary.

## Additional Information
<!--
Is there anything else your fellow developers need to know in evaluating this pull request?
Feel free to add supplementary material here (e.g. screen output, log files, screenshots)
-->

## Interested Parties / Possible Reviewers
<!--
If there's any developer, who you think should be looped in on this pull request, feel free to @mention them here.
-->

FYI @amgebauer 