### PR TITLE
Fix two warnings when compiling with Clang

### DIFF
--- a/src/mirco_topology.cpp
+++ b/src/mirco_topology.cpp
@@ -22,7 +22,7 @@ void MIRCO::ReadFile::GetSurface(Teuchos::SerialDenseMatrix<int, double> &z)
   }
   reader.close();
   z.shape(dimension, dimension);
-  int position = 0, separatorPosition, lineCounter = 0;
+  int separatorPosition, lineCounter = 0;
   std::ifstream stream(TopologyFilePath);
   std::string line, container;
   double value;
@@ -34,7 +34,6 @@ void MIRCO::ReadFile::GetSurface(Teuchos::SerialDenseMatrix<int, double> &z)
     {
       separatorPosition = line.find_first_of(';');
       container = line.substr(0, separatorPosition);
-      position += 1;
       line = line.substr(separatorPosition + 1, line.length());
       value = stod(container);
       z(lineCounter - 1, i) = value;

--- a/src/mirco_topology.h
+++ b/src/mirco_topology.h
@@ -22,6 +22,8 @@ namespace MIRCO
      */
     virtual void GetSurface(Teuchos::SerialDenseMatrix<int, double> &z) = 0;
     TopologyGeneration(int nn) { resolution = nn; }
+
+    virtual ~TopologyGeneration() = default;
   };
 
   class ReadFile : public TopologyGeneration


### PR DESCRIPTION
While experimenting with the build system in BACI, I found two warnings when compiling MIRCO with Clang. While there is, of course, no need to adapt to warning flags of an upstream project (they should keep them only to themselves) I believe we might as well fix them here. One warning points to an unused variable, the other one to a missing virtual destructor.