### PR TITLE
Convert classes without member variables into namespaces

### DIFF
--- a/src/mirco_evaluate.cpp
+++ b/src/mirco_evaluate.cpp
@@ -70,8 +70,7 @@ void MIRCO::Evaluate(double& pressure, const double Delta, const double LateralL
     A.shape(xv0.size(), xv0.size());
 
     // Construction of the Matrix A
-    MIRCO::MatrixGeneration matrix1;
-    matrix1.SetUpMatrix(A, xv0, yv0, GridSize, CompositeYoungs, n0, PressureGreenFunFlag);
+    MIRCO::MatrixGeneration::SetUpMatrix(A, xv0, yv0, GridSize, CompositeYoungs, n0, PressureGreenFunFlag);
 
     // Second predictor for contact set
     // @{
@@ -85,8 +84,7 @@ void MIRCO::Evaluate(double& pressure, const double Delta, const double LateralL
 
     // use Nonlinear solver --> Non-Negative Least Squares (NNLS) as in
     // (Bemporad & Paggi, 2015)
-    MIRCO::NonLinearSolver solution2;
-    solution2.NonlinearSolve(A, b0, x0, w, y);
+    MIRCO::NonLinearSolver::Solve(A, b0, x0, w, y);
 
     // Compute number of contact node
     MIRCO::ComputeContactNodes(xvf, yvf, pf, nf, y, xv0, yv0);

--- a/src/mirco_linearsolver.h
+++ b/src/mirco_linearsolver.h
@@ -7,9 +7,8 @@
 
 namespace MIRCO
 {
-  class LinearSolver
+  namespace LinearSolver
   {
-   public:
     /**
      * @brief Solver the linear system matrix * vector_x = vector_b
      *

--- a/src/mirco_matrixsetup.h
+++ b/src/mirco_matrixsetup.h
@@ -6,9 +6,8 @@
 
 namespace MIRCO
 {
-  class MatrixGeneration
+  namespace MatrixGeneration
   {
-   public:
     /**
      * @brief The aim of this function is to create the influence coefficient matrix (Discrete
      * version of Green function)

--- a/src/mirco_nonlinearsolver.cpp
+++ b/src/mirco_nonlinearsolver.cpp
@@ -149,8 +149,7 @@ void MIRCO::NonLinearSolver::NonlinearSolve(const Teuchos::SerialDenseMatrix<int
         }
       }
       // Solving solverMatrix*vector_x=vector_b
-      MIRCO::LinearSolver solution;
-      solution.Solve(solverMatrix, vector_x, vector_b);
+      MIRCO::LinearSolver::Solve(solverMatrix, vector_x, vector_b);
 
 #pragma omp parallel for schedule(static, 16)  // Always same workload -> Static!
       for (int x = 0; x < counter; x++)

--- a/src/mirco_nonlinearsolver.cpp
+++ b/src/mirco_nonlinearsolver.cpp
@@ -7,7 +7,7 @@
 
 #include "mirco_linearsolver.h"
 
-void MIRCO::NonLinearSolver::NonlinearSolve(const Teuchos::SerialDenseMatrix<int, double>& matrix,
+void MIRCO::NonLinearSolver::Solve(const Teuchos::SerialDenseMatrix<int, double>& matrix,
     const std::vector<double>& b0, const Teuchos::SerialDenseMatrix<int, double>& y0,
     Teuchos::SerialDenseMatrix<int, double>& w, Teuchos::SerialDenseVector<int, double>& y)
 {

--- a/src/mirco_nonlinearsolver.h
+++ b/src/mirco_nonlinearsolver.h
@@ -7,9 +7,8 @@
 
 namespace MIRCO
 {
-  class NonLinearSolver
+  namespace NonLinearSolver
   {
-   public:
     /**
      * @brief Solve the non-linear set of equations using Non-Negative Least Squares (NNLS) method.
      *
@@ -20,7 +19,7 @@ namespace MIRCO
      * @param w Gap between the point on the topology and the half space
      * @param y Solution containing force
      */
-    void NonlinearSolve(const Teuchos::SerialDenseMatrix<int, double>& matrix,
+    void Solve(const Teuchos::SerialDenseMatrix<int, double>& matrix,
         const std::vector<double>& b0, const Teuchos::SerialDenseMatrix<int, double>& y0,
         Teuchos::SerialDenseMatrix<int, double>& w, Teuchos::SerialDenseVector<int, double>& y);
   };

--- a/tests/unittests/test.cpp
+++ b/tests/unittests/test.cpp
@@ -45,8 +45,7 @@ TEST(linearsolver, solves)
   }
 
   // Call linear solver
-  MIRCO::LinearSolver linearsolver;
-  linearsolver.Solve(topology, vector_x, vector_b);
+  MIRCO::LinearSolver::Solve(topology, vector_x, vector_b);
 
   EXPECT_NEAR(vector_x(0), 0.333333333333333, 1e-06);
   EXPECT_NEAR(vector_x(1), 0.333333333333333, 1e-06);

--- a/tests/unittests/test.cpp
+++ b/tests/unittests/test.cpp
@@ -53,8 +53,7 @@ TEST(linearsolver, solves)
 
 TEST_F(NonlinearSolverTest, primalvariable)
 {
-  MIRCO::NonLinearSolver nonlinearsolver;
-  nonlinearsolver.NonlinearSolve(matrix_, b_vector_, x_vector_, w_, y_);
+  MIRCO::NonLinearSolver::Solve(matrix_, b_vector_, x_vector_, w_, y_);
 
   EXPECT_NEAR(y_(0), 163213.374921086, 1e-06);
   EXPECT_NEAR(y_(1), 43877.9231473546, 1e-06);
@@ -69,8 +68,7 @@ TEST_F(NonlinearSolverTest, primalvariable)
 
 TEST_F(NonlinearSolverTest, dualvariable)
 {
-  MIRCO::NonLinearSolver nonlinearsolver;
-  nonlinearsolver.NonlinearSolve(matrix_, b_vector_, x_vector_, w_, y_);
+  MIRCO::NonLinearSolver::Solve(matrix_, b_vector_, x_vector_, w_, y_);
 
   EXPECT_NEAR(w_(0, 0), 0, 1e-06);
   EXPECT_NEAR(w_(1, 0), 0, 1e-06);


### PR DESCRIPTION
## Description and Context
The `NonLinearSolver`, `LinearSolver`, and `MatrixGeneration` classes consist purely of essentially const functions. This small change converts them into namespaces (in case other functions are added into the same file at a later point).

## Related Issues and Pull Requests
Closes https://github.com/imcs-compsim/MIRCO/issues/105

## Interested Parties / Possible Reviewers
@mayrmt 
