### PR TITLE
Kokkos integration: Fix conflict between nvcc and rapidyaml

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,8 +29,8 @@ jobs:
             exit 1
           fi
 
-  mirco-test:
-    name: mirco_test_full
+  mirco-test-kokkosopenmp:
+    name: mirco_test_kokkosopenmp
     runs-on: ubuntu-latest
 
     container:
@@ -49,8 +49,8 @@ jobs:
 
       - name: Build and test
         run: |
-          mkdir mirco-build
-          cd mirco-build
-          cmake --preset=docker_container ../mirco-src/
+          mkdir mirco-build_kokkosopenmp
+          cd mirco-build_kokkosopenmp
+          cmake --preset=docker_container_kokkosopenmp ../mirco-src/
           ninja -j 12
           ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,14 +127,95 @@ add_library(mirco_inputparameters
 target_link_libraries(mirco_inputparameters PRIVATE mirco_topology Kokkos::kokkos)
 
 # Fetch rapidyaml (ryml) directly
-include(FetchContent)
-FetchContent_Declare(rapidyaml GIT_REPOSITORY https://github.com/biojppm/rapidyaml.git GIT_TAG 47ec2fa184209687c20fd5bc05621e1cb1200311)
-FetchContent_MakeAvailable(rapidyaml)
+#include(FetchContent)
+##set(C4CORE_WITH_FASTFLOAT OFF CACHE BOOL "disable fastfloat in c4core" FORCE)
+#FetchContent_Declare(rapidyaml GIT_REPOSITORY https://github.com/biojppm/rapidyaml.git GIT_TAG 47ec2fa184209687c20fd5bc05621e1cb1200311)
+#FetchContent_MakeAvailable(rapidyaml)
+
+
+
+
+
+
+
+
+
+
+include(ExternalProject)
+
+set(HOST_PREFIX ${CMAKE_BINARY_DIR}/_hostdeps)
+set(HOST_CXX /usr/bin/g++-12)
+
+ExternalProject_Add(ryml_build
+  GIT_REPOSITORY https://github.com/biojppm/rapidyaml.git
+  GIT_TAG 47ec2fa184209687c20fd5bc05621e1cb1200311
+  INSTALL_DIR ${HOST_PREFIX}
+  CMAKE_ARGS
+    -DCMAKE_CXX_COMPILER=${HOST_CXX}
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    -DCMAKE_POLICY_DEFAULT_CMP0077=NEW
+    -DC4CORE_WITH_FASTFLOAT=OFF
+    -DC4CORE_INSTALL=ON
+    -DRYML_BUILD_TESTS=OFF
+    -DRYML_BUILD_BENCHMARKS=OFF
+    -DCMAKE_CXX_FLAGS=-w
+    -DCMAKE_C_FLAGS=-w
+  INSTALL_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --target install --config $<CONFIG>
+  BUILD_BYPRODUCTS ${HOST_PREFIX}/lib/libryml.a
+)
+
+file(MAKE_DIRECTORY ${HOST_PREFIX}/include ${HOST_PREFIX}/lib)
+
+add_library(ryml_import STATIC IMPORTED)
+set_target_properties(ryml_import PROPERTIES
+  IMPORTED_LOCATION ${HOST_PREFIX}/lib/libryml.a
+  INTERFACE_INCLUDE_DIRECTORIES ${HOST_PREFIX}/include
+  INTERFACE_COMPILE_DEFINITIONS C4CORE_NO_FAST_FLOAT)
+add_dependencies(ryml_import ryml_build)
+
+add_library(ryml_host INTERFACE)
+add_dependencies(ryml_host ryml_build)
+target_include_directories(ryml_host INTERFACE ${HOST_PREFIX}/include)
+target_link_libraries(ryml_host INTERFACE ${HOST_PREFIX}/lib/libryml.a)
+target_compile_definitions(ryml_host INTERFACE C4CORE_NO_FAST_FLOAT)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 add_library(mirco_utils
   src/mirco_utils.cpp
   )
-target_link_libraries(mirco_utils PUBLIC ryml)
+
+target_link_libraries(mirco_utils PUBLIC ryml_host)#ryml)
+
+
+
+
+
+
+
+
+
+
+
 
 add_library(mirco_inputparameters_yaml
   src/mirco_inputparameters_yaml.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,96 +126,67 @@ add_library(mirco_inputparameters
   )
 target_link_libraries(mirco_inputparameters PRIVATE mirco_topology Kokkos::kokkos)
 
-# Fetch rapidyaml (ryml) directly
-#include(FetchContent)
-##set(C4CORE_WITH_FASTFLOAT OFF CACHE BOOL "disable fastfloat in c4core" FORCE)
-#FetchContent_Declare(rapidyaml GIT_REPOSITORY https://github.com/biojppm/rapidyaml.git GIT_TAG 47ec2fa184209687c20fd5bc05621e1cb1200311)
-#FetchContent_MakeAvailable(rapidyaml)
 
+if(Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP OR Kokkos_ENABLE_SYCL OR Kokkos_ENABLE_OPENMPTARGET)
+  # Compile rapidyaml (ryml) separately to avoid conflicts with device-side/offloaded compilers (e.g. nvcc_wrapper)
+  include(ExternalProject)
+  set(RYML_INSTALL_DIR ${CMAKE_BINARY_DIR}/extern/ryml)
 
+  if(NOT DEFINED MIRCO_HOST_CXX_COMPILER)
+    set(MIRCO_HOST_CXX_COMPILER "g++-12")
+  endif()
 
+  ExternalProject_Add(ryml_build
+    GIT_REPOSITORY https://github.com/biojppm/rapidyaml.git
+    GIT_TAG 47ec2fa184209687c20fd5bc05621e1cb1200311
+    INSTALL_DIR ${RYML_INSTALL_DIR}
+    CMAKE_ARGS
+      -DCMAKE_CXX_COMPILER=${MIRCO_HOST_CXX_COMPILER}
+      -DCMAKE_BUILD_TYPE=Release
+      -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+      -DCMAKE_POLICY_DEFAULT_CMP0077=NEW
+      -DC4CORE_WITH_FASTFLOAT=OFF
+      -DC4CORE_INSTALL=ON
+      -DRYML_BUILD_TESTS=OFF
+      -DRYML_BUILD_BENCHMARKS=OFF
+      -DCMAKE_CXX_FLAGS=-w
+    INSTALL_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --target install --config $<CONFIG>
+    BUILD_BYPRODUCTS ${RYML_INSTALL_DIR}/lib/libryml.a
+  )
 
+  file(MAKE_DIRECTORY ${RYML_INSTALL_DIR}/include ${RYML_INSTALL_DIR}/lib)
 
+  add_library(ryml_import STATIC IMPORTED)
+  set_target_properties(ryml_import PROPERTIES
+    IMPORTED_LOCATION ${RYML_INSTALL_DIR}/lib/libryml.a
+    INTERFACE_INCLUDE_DIRECTORIES ${RYML_INSTALL_DIR}/include
+    INTERFACE_COMPILE_DEFINITIONS C4CORE_NO_FAST_FLOAT)
+  add_dependencies(ryml_import ryml_build)
 
+  add_library(ryml INTERFACE)
+  add_dependencies(ryml ryml_build)
+  target_include_directories(ryml INTERFACE ${RYML_INSTALL_DIR}/include)
+  target_link_libraries(ryml INTERFACE ${RYML_INSTALL_DIR}/lib/libryml.a)
+  target_compile_definitions(ryml INTERFACE C4CORE_NO_FAST_FLOAT)
 
-
-
-
-include(ExternalProject)
-
-set(HOST_PREFIX ${CMAKE_BINARY_DIR}/_hostdeps)
-set(HOST_CXX /usr/bin/g++-12)
-
-ExternalProject_Add(ryml_build
-  GIT_REPOSITORY https://github.com/biojppm/rapidyaml.git
-  GIT_TAG 47ec2fa184209687c20fd5bc05621e1cb1200311
-  INSTALL_DIR ${HOST_PREFIX}
-  CMAKE_ARGS
-    -DCMAKE_CXX_COMPILER=${HOST_CXX}
-    -DCMAKE_BUILD_TYPE=Release
-    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-    -DCMAKE_POLICY_DEFAULT_CMP0077=NEW
-    -DC4CORE_WITH_FASTFLOAT=OFF
-    -DC4CORE_INSTALL=ON
-    -DRYML_BUILD_TESTS=OFF
-    -DRYML_BUILD_BENCHMARKS=OFF
-    -DCMAKE_CXX_FLAGS=-w
-    -DCMAKE_C_FLAGS=-w
-  INSTALL_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --target install --config $<CONFIG>
-  BUILD_BYPRODUCTS ${HOST_PREFIX}/lib/libryml.a
-)
-
-file(MAKE_DIRECTORY ${HOST_PREFIX}/include ${HOST_PREFIX}/lib)
-
-add_library(ryml_import STATIC IMPORTED)
-set_target_properties(ryml_import PROPERTIES
-  IMPORTED_LOCATION ${HOST_PREFIX}/lib/libryml.a
-  INTERFACE_INCLUDE_DIRECTORIES ${HOST_PREFIX}/include
-  INTERFACE_COMPILE_DEFINITIONS C4CORE_NO_FAST_FLOAT)
-add_dependencies(ryml_import ryml_build)
-
-add_library(ryml_host INTERFACE)
-add_dependencies(ryml_host ryml_build)
-target_include_directories(ryml_host INTERFACE ${HOST_PREFIX}/include)
-target_link_libraries(ryml_host INTERFACE ${HOST_PREFIX}/lib/libryml.a)
-target_compile_definitions(ryml_host INTERFACE C4CORE_NO_FAST_FLOAT)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  ExternalProject_Add_Step(ryml_build cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm -rf <SOURCE_DIR> <BINARY_DIR> <STAMP_DIR> <TMP_DIR> <DOWNLOAD_DIR>
+    COMMENT "Cleaning ryml external project work directories"
+    DEPENDEES install
+    ALWAYS TRUE
+  )
+else()
+  # Everything is compiled on host; fetch rapidyaml directly
+  include(FetchContent)
+  FetchContent_Declare(rapidyaml GIT_REPOSITORY https://github.com/biojppm/rapidyaml.git GIT_TAG 47ec2fa184209687c20fd5bc05621e1cb1200311)
+  FetchContent_MakeAvailable(rapidyaml)
+endif()
 
 add_library(mirco_utils
   src/mirco_utils.cpp
   )
 
-target_link_libraries(mirco_utils PUBLIC ryml_host)#ryml)
-
-
-
-
-
-
-
-
-
-
-
+target_link_libraries(mirco_utils PUBLIC ryml)
 
 add_library(mirco_inputparameters_yaml
   src/mirco_inputparameters_yaml.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,6 @@ add_library(mirco_inputparameters
   )
 target_link_libraries(mirco_inputparameters PRIVATE mirco_topology Kokkos::kokkos)
 
-
 if(Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP OR Kokkos_ENABLE_SYCL OR Kokkos_ENABLE_OPENMPTARGET)
   # Compile rapidyaml (ryml) separately to avoid conflicts with device-side/offloaded compilers (e.g. nvcc_wrapper)
   include(ExternalProject)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,7 +8,6 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RELEASE",
         "CMAKE_CXX_COMPILER": "mpicxx",
-        "CMAKE_C_COMPILER": "gcc",
         "CMAKE_C_COMPILER_LAUNCHER": "ccache",
         "CMAKE_CXX_FLAGS": "",
         "GTEST_IN_MIRCO": "ON"
@@ -21,8 +20,8 @@
         ".base"
       ],
       "cacheVariables": {
-        "KOKKOS_PATH": "/opt/mirco-dependencies/kokkos_install",
-        "KOKKOS_KERNELS_PATH": "/opt/mirco-dependencies/kokkos-kernels_install",
+        "KOKKOS_PATH": "/opt/mirco-dependencies/kokkos_install_openmp",
+        "KOKKOS_KERNELS_PATH": "/opt/mirco-dependencies/kokkos-kernels_install_openmp",
         "KOKKOS_IN_MIRCO": "ON",
         "KOKKOS_KERNELS_IN_MIRCO": "ON"
       }
@@ -34,32 +33,12 @@
         ".base"
       ],
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "gcc-12",
-        "CMAKE_CXX_COMPILER": "g++-12",
+        "CMAKE_CXX_COMPILER": "/opt/mirco-dependencies/kokkos/bin/nvcc_wrapper",
         "MIRCO_HOST_CXX_COMPILER": "g++-12",
-        "KOKKOS_PATH": "/opt/mirco-dependencies/kokkos_install",
-        "KOKKOS_KERNELS_PATH": "/opt/mirco-dependencies/kokkos-kernels_install",
+        "KOKKOS_PATH": "/opt/mirco-dependencies/kokkos_install_cuda",
+        "KOKKOS_KERNELS_PATH": "/opt/mirco-dependencies/kokkos-kernels_install_cuda",
         "KOKKOS_IN_MIRCO": "ON",
         "KOKKOS_KERNELS_IN_MIRCO": "ON"
-      }
-    },
-    {
-      "name": "kokkos_cuda",
-      "displayName": "Example of basic Kokkos configuration using the CUDA backend",
-      "hidden": false,
-      "generator": "Ninja",
-      "cacheVariables": {
-        "CMAKE_INSTALL_PREFIX": "../install_tmp",
-        "CMAKE_BUILD_TYPE": "RELEASE",
-        "CMAKE_C_COMPILER": "/usr/bin/gcc-12",
-        "CMAKE_CXX_COMPILER": "/usr/bin/g++-12",
-        "MIRCO_HOST_CXX_COMPILER": "/usr/bin/g++-12",
-        "KOKKOS_PATH": "/home/oesterle/rd/kokkos_Base/debug_develop_cuda/installRel",
-        "KOKKOS_KERNELS_PATH": "/home/oesterle/rd/kokkos-kernels_Base/debug_develop_cuda/installRel",
-        "KOKKOS_IN_MIRCO": "ON",
-        "KOKKOS_KERNELS_IN_MIRCO": "ON",
-        "GTEST_IN_MIRCO": "ON",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,7 +15,7 @@
       }
     },
     {
-      "name": "docker_container",
+      "name": "docker_container_kokkosopenmp",
       "displayName": "Release build using Kokkos with OpenMP backend for CI/CD testing in a docker container",
       "inherits": [
         ".base"
@@ -25,6 +25,41 @@
         "KOKKOS_KERNELS_PATH": "/opt/mirco-dependencies/kokkos-kernels_install",
         "KOKKOS_IN_MIRCO": "ON",
         "KOKKOS_KERNELS_IN_MIRCO": "ON"
+      }
+    },
+    {
+      "name": "docker_container_kokkoscuda",
+      "displayName": "Release build using Kokkos with CUDA backend for CI/CD testing in a docker container",
+      "inherits": [
+        ".base"
+      ],
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc-12",
+        "CMAKE_CXX_COMPILER": "g++-12",
+        "MIRCO_HOST_CXX_COMPILER": "g++-12",
+        "KOKKOS_PATH": "/opt/mirco-dependencies/kokkos_install",
+        "KOKKOS_KERNELS_PATH": "/opt/mirco-dependencies/kokkos-kernels_install",
+        "KOKKOS_IN_MIRCO": "ON",
+        "KOKKOS_KERNELS_IN_MIRCO": "ON"
+      }
+    },
+    {
+      "name": "kokkos_cuda",
+      "displayName": "Example of basic Kokkos configuration using the CUDA backend",
+      "hidden": false,
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_INSTALL_PREFIX": "../install_tmp",
+        "CMAKE_BUILD_TYPE": "RELEASE",
+        "CMAKE_C_COMPILER": "/usr/bin/gcc-12",
+        "CMAKE_CXX_COMPILER": "/usr/bin/g++-12",
+        "MIRCO_HOST_CXX_COMPILER": "/usr/bin/g++-12",
+        "KOKKOS_PATH": "/home/oesterle/rd/kokkos_Base/debug_develop_cuda/installRel",
+        "KOKKOS_KERNELS_PATH": "/home/oesterle/rd/kokkos-kernels_Base/debug_develop_cuda/installRel",
+        "KOKKOS_IN_MIRCO": "ON",
+        "KOKKOS_KERNELS_IN_MIRCO": "ON",
+        "GTEST_IN_MIRCO": "ON",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     },
     {

--- a/Input/input_sup7.yaml
+++ b/Input/input_sup7.yaml
@@ -19,7 +19,7 @@ mirco_input:
       Delta: 10.0
       Tolerance: 0.01
   result_description:
-    ExpectedPressure: 0.004526213923013545
+    ExpectedPressure: 0.0004526213923013545
     ExpectedPressureTolerance: 1e-10
-    ExpectedEffectiveContactAreaFraction: 0.06970734931794964
+    ExpectedEffectiveContactAreaFraction: 0.006970734931794964
     ExpectedEffectiveContactAreaFractionTolerance: 1e-10

--- a/Input/input_sup7.yaml
+++ b/Input/input_sup7.yaml
@@ -19,7 +19,7 @@ mirco_input:
       Delta: 10.0
       Tolerance: 0.01
   result_description:
-    ExpectedPressure: 0.0004526213923013545
+    ExpectedPressure: 0.004526213923013545
     ExpectedPressureTolerance: 1e-10
-    ExpectedEffectiveContactAreaFraction: 0.006970734931794964
+    ExpectedEffectiveContactAreaFraction: 0.06970734931794964
     ExpectedEffectiveContactAreaFractionTolerance: 1e-10

--- a/dependencies/kokkos-kernels/install.sh
+++ b/dependencies/kokkos-kernels/install.sh
@@ -21,7 +21,7 @@ cd kokkos-kernels
 git checkout $VERSION
 cd .. && mkdir kokkos-kernels_build && cd kokkos-kernels_build
 
-# Buld and install with OpenMP backend
+# Build and install with OpenMP backend
 $CMAKE_COMMAND \
   -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
   -D CMAKE_CXX_STANDARD:STRING="17" \
@@ -29,7 +29,7 @@ $CMAKE_COMMAND \
   -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos-kernels_install_openmp \
   -D BUILD_SHARED_LIBS:BOOL=OFF \
   \
-  -D Kokkos_ROOT=$DEPS_ROOT/../kokkos_install_openmp \
+  -D Kokkos_ROOT=$DEPS_ROOT/kokkos_install_openmp \
   \
   -D KokkosKernels_ENABLE_TPL_BLAS=ON \
   -D KokkosKernels_ENABLE_TPL_LAPACK=ON \
@@ -42,24 +42,24 @@ make -j${NPROCS} install
 # Clean build dir
 rm -rf *
 
-# Buld and install with Serial+CUDA backend
-$CMAKE_COMMAND \
-  -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
-  -D CMAKE_CXX_STANDARD:STRING="17" \
-  -D CMAKE_CXX_COMPILER=g++ \
-  -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos-kernels_install_cuda \
-  -D BUILD_SHARED_LIBS:BOOL=OFF \
-  \
-  -D Kokkos_ROOT=$DEPS_ROOT/../kokkos_install_cuda \
-  \
-  -D KokkosKernels_ENABLE_TPL_BLAS=ON \
-  -D KokkosKernels_ENABLE_TPL_LAPACK=ON \
-  -D KokkosKernels_ENABLE_TPL_CUSOLVER=ON \
-  \
-  -D Kokkos_ENABLE_SERIAL=ON \
-  -D Kokkos_ENABLE_CUDA=ON \
-  \
-  ../kokkos-kernels
-make -j${NPROCS} install
+# Build and install with Serial+CUDA backend
+#$CMAKE_COMMAND \
+#  -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
+#  -D CMAKE_CXX_STANDARD:STRING="17" \
+#  -D CMAKE_CXX_COMPILER=g++ \
+#  -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos-kernels_install_cuda \
+#  -D BUILD_SHARED_LIBS:BOOL=OFF \
+#  \
+#  -D Kokkos_ROOT=$DEPS_ROOT/kokkos_install_cuda \
+#  \
+#  -D KokkosKernels_ENABLE_TPL_BLAS=ON \
+#  -D KokkosKernels_ENABLE_TPL_LAPACK=ON \
+#  -D KokkosKernels_ENABLE_TPL_CUSOLVER=ON \
+#  \
+#  -D Kokkos_ENABLE_SERIAL=ON \
+#  -D Kokkos_ENABLE_CUDA=ON \
+#  \
+#  ../kokkos-kernels
+#make -j${NPROCS} install
 
-rm -rf kokkos-kernels kokkos-kernels_build
+cd .. && rm -rf kokkos-kernels kokkos-kernels_build

--- a/dependencies/kokkos-kernels/install.sh
+++ b/dependencies/kokkos-kernels/install.sh
@@ -7,7 +7,7 @@
 # Exit the script at the first failure
 set -e
 
-INSTALL_ROOT="$1"
+DEPS_ROOT="$1"
 # Number of procs for building (default 4)
 NPROCS=${NPROCS:=4}
 # git sha from Kokkos-Kernels repository:
@@ -15,6 +15,7 @@ VERSION="3254a1c1ccda11673fad64651dd8ab957bf49e7d"
 
 CMAKE_COMMAND=cmake
 
+cd $DEPS_ROOT
 git clone https://github.com/kokkos/kokkos-kernels.git kokkos-kernels
 cd kokkos-kernels
 git checkout $VERSION
@@ -25,10 +26,10 @@ $CMAKE_COMMAND \
   -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
   -D CMAKE_CXX_STANDARD:STRING="17" \
   -D CMAKE_CXX_COMPILER=g++ \
-  -D CMAKE_INSTALL_PREFIX:STRING=$INSTALL_ROOT/kokkos-kernels_install_openmp \
+  -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos-kernels_install_openmp \
   -D BUILD_SHARED_LIBS:BOOL=OFF \
   \
-  -D Kokkos_ROOT=$INSTALL_ROOT/../kokkos_install_openmp \
+  -D Kokkos_ROOT=$DEPS_ROOT/../kokkos_install_openmp \
   \
   -D KokkosKernels_ENABLE_TPL_BLAS=ON \
   -D KokkosKernels_ENABLE_TPL_LAPACK=ON \
@@ -46,10 +47,10 @@ $CMAKE_COMMAND \
   -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
   -D CMAKE_CXX_STANDARD:STRING="17" \
   -D CMAKE_CXX_COMPILER=g++ \
-  -D CMAKE_INSTALL_PREFIX:STRING=$INSTALL_ROOT/kokkos-kernels_install_cuda \
+  -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos-kernels_install_cuda \
   -D BUILD_SHARED_LIBS:BOOL=OFF \
   \
-  -D Kokkos_ROOT=$INSTALL_ROOT/../kokkos_install_cuda \
+  -D Kokkos_ROOT=$DEPS_ROOT/../kokkos_install_cuda \
   \
   -D KokkosKernels_ENABLE_TPL_BLAS=ON \
   -D KokkosKernels_ENABLE_TPL_LAPACK=ON \
@@ -61,4 +62,4 @@ $CMAKE_COMMAND \
   ../kokkos-kernels
 make -j${NPROCS} install
 
-rm -rf kokkos kokkos_build
+rm -rf kokkos-kernels kokkos-kernels_build

--- a/dependencies/kokkos/install.sh
+++ b/dependencies/kokkos/install.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# Install Kokkos with OpenMP backend
+# Install Kokkos with OpenMP and with Serial+CUDA backends (separately)
 # Call with
-# ./install.sh /path/to/install/dir
+# ./install.sh /path/to/install/root
 
 # Exit the script at the first failure
 set -e
 
-INSTALL_DIR="$1"
+INSTALL_ROOT="$1"
 # Number of procs for building (default 4)
 NPROCS=${NPROCS:=4}
 # git sha from Kokkos repository:
@@ -20,17 +20,34 @@ cd kokkos
 git checkout $VERSION
 cd .. && mkdir kokkos_build && cd kokkos_build
 
+# Buld and install with OpenMP backend
 $CMAKE_COMMAND \
   -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
   -D CMAKE_CXX_STANDARD:STRING="17" \
   -D CMAKE_CXX_COMPILER=g++ \
-  -D CMAKE_INSTALL_PREFIX:STRING=$INSTALL_DIR \
+  -D CMAKE_INSTALL_PREFIX:STRING=$INSTALL_ROOT/kokkos_install_openmp \
   -D BUILD_SHARED_LIBS:BOOL=OFF \
   \
   -D Kokkos_ENABLE_OPENMP=ON \
   \
   ../kokkos
-
 make -j${NPROCS} install
-cd ..
+
+# Clean build dir
+rm -rf *
+
+# Buld and install with Serial+CUDA backend
+$CMAKE_COMMAND \
+  -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
+  -D CMAKE_CXX_STANDARD:STRING="17" \
+  -D CMAKE_CXX_COMPILER=g++ \
+  -D CMAKE_INSTALL_PREFIX:STRING=$INSTALL_ROOT/kokkos_install_cuda \
+  -D BUILD_SHARED_LIBS:BOOL=OFF \
+  \
+  -D Kokkos_ENABLE_SERIAL=ON \
+  -D Kokkos_ENABLE_CUDA=ON \
+  \
+  ../kokkos
+make -j${NPROCS} install
+
 rm -rf kokkos kokkos_build

--- a/dependencies/kokkos/install.sh
+++ b/dependencies/kokkos/install.sh
@@ -21,7 +21,7 @@ cd kokkos
 git checkout $VERSION
 cd .. && mkdir kokkos_build && cd kokkos_build
 
-# Buld and install with OpenMP backend
+# Build and install with OpenMP backend
 $CMAKE_COMMAND \
   -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
   -D CMAKE_CXX_STANDARD:STRING="17" \
@@ -37,19 +37,19 @@ make -j${NPROCS} install
 # Clean build dir
 rm -rf *
 
-# Buld and install with Serial+CUDA backend
-$CMAKE_COMMAND \
-  -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
-  -D CMAKE_CXX_STANDARD:STRING="17" \
-  -D CMAKE_CXX_COMPILER=g++ \
-  -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos_install_cuda \
-  -D BUILD_SHARED_LIBS:BOOL=OFF \
-  \
-  -D Kokkos_ENABLE_SERIAL=ON \
-  -D Kokkos_ENABLE_CUDA=ON \
-  \
-  ../kokkos
-make -j${NPROCS} install
+# Build and install with Serial+CUDA backend
+#$CMAKE_COMMAND \
+#  -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
+#  -D CMAKE_CXX_STANDARD:STRING="17" \
+#  -D CMAKE_CXX_COMPILER=g++ \
+#  -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos_install_cuda \
+#  -D BUILD_SHARED_LIBS:BOOL=OFF \
+#  \
+#  -D Kokkos_ENABLE_SERIAL=ON \
+#  -D Kokkos_ENABLE_CUDA=ON \
+#  \
+#  ../kokkos
+#make -j${NPROCS} install
 
 # keep kokkos (src) for nvcc_wrapper
-rm -rf kokkos_build
+cd .. && rm -rf kokkos_build

--- a/dependencies/kokkos/install.sh
+++ b/dependencies/kokkos/install.sh
@@ -7,7 +7,7 @@
 # Exit the script at the first failure
 set -e
 
-INSTALL_ROOT="$1"
+DEPS_ROOT="$1"
 # Number of procs for building (default 4)
 NPROCS=${NPROCS:=4}
 # git sha from Kokkos repository:
@@ -15,6 +15,7 @@ VERSION="f11fb0be01b0bcb2d7fa9eda41f2fe79d63e859b"
 
 CMAKE_COMMAND=cmake
 
+cd $DEPS_ROOT
 git clone https://github.com/kokkos/kokkos.git kokkos
 cd kokkos
 git checkout $VERSION
@@ -25,7 +26,7 @@ $CMAKE_COMMAND \
   -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
   -D CMAKE_CXX_STANDARD:STRING="17" \
   -D CMAKE_CXX_COMPILER=g++ \
-  -D CMAKE_INSTALL_PREFIX:STRING=$INSTALL_ROOT/kokkos_install_openmp \
+  -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos_install_openmp \
   -D BUILD_SHARED_LIBS:BOOL=OFF \
   \
   -D Kokkos_ENABLE_OPENMP=ON \
@@ -41,7 +42,7 @@ $CMAKE_COMMAND \
   -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
   -D CMAKE_CXX_STANDARD:STRING="17" \
   -D CMAKE_CXX_COMPILER=g++ \
-  -D CMAKE_INSTALL_PREFIX:STRING=$INSTALL_ROOT/kokkos_install_cuda \
+  -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos_install_cuda \
   -D BUILD_SHARED_LIBS:BOOL=OFF \
   \
   -D Kokkos_ENABLE_SERIAL=ON \
@@ -50,4 +51,5 @@ $CMAKE_COMMAND \
   ../kokkos
 make -j${NPROCS} install
 
-rm -rf kokkos kokkos_build
+# keep kokkos (src) for nvcc_wrapper
+rm -rf kokkos_build

--- a/docker/dependencies/Dockerfile
+++ b/docker/dependencies/Dockerfile
@@ -48,14 +48,14 @@ RUN apt-get update && apt-get install -y \
 # Create directory for dependencies
 ARG NPROCS=12
 ENV NPROCS=$NPROCS \
-    INSTALL_DIR="/opt/mirco-dependencies"
-RUN mkdir -p ${INSTALL_DIR}
+    INSTALL_ROOT="/opt/mirco-dependencies"
+RUN mkdir -p ${INSTALL_ROOT}
 
 COPY dependencies /dependencies
 
 # Install Kokkos and Kokkos-Kernels
-RUN /dependencies/kokkos/install.sh ${INSTALL_DIR}/kokkos_install
-RUN /dependencies/kokkos-kernels/install.sh ${INSTALL_DIR}/kokkos-kernels_install
+RUN /dependencies/kokkos/install.sh ${INSTALL_ROOT}
+RUN /dependencies/kokkos-kernels/install.sh ${INSTALL_ROOT}
 
 # Add dependencies hash
 # The label is added at the end because the label causes a cache miss

--- a/docker/dependencies/Dockerfile
+++ b/docker/dependencies/Dockerfile
@@ -48,14 +48,14 @@ RUN apt-get update && apt-get install -y \
 # Create directory for dependencies
 ARG NPROCS=12
 ENV NPROCS=$NPROCS \
-    INSTALL_ROOT="/opt/mirco-dependencies"
-RUN mkdir -p ${INSTALL_ROOT}
+    DEPS_ROOT="/opt/mirco-dependencies"
+RUN mkdir -p ${DEPS_ROOT}
 
 COPY dependencies /dependencies
 
 # Install Kokkos and Kokkos-Kernels
-RUN /dependencies/kokkos/install.sh ${INSTALL_ROOT}
-RUN /dependencies/kokkos-kernels/install.sh ${INSTALL_ROOT}
+RUN /dependencies/kokkos/install.sh ${DEPS_ROOT}
+RUN /dependencies/kokkos-kernels/install.sh ${DEPS_ROOT}
 
 # Add dependencies hash
 # The label is added at the end because the label causes a cache miss

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,13 +16,14 @@ int main(int argc, char* argv[])
 {
   Kokkos::initialize(argc, argv);
   {
-    std::cout << "-- Kokkos info --\n";
+    std::cout << "-- Kokkos information --\n";
     std::cout << "threads_in_use = " << ExecSpace_Default_t::concurrency() << "\n";
-    std::cout << "ExecSpace_Default = " << typeid(ExecSpace_Default_t).name() << "\n";
-    std::cout << "ExecSpace_DefaultHost = " << typeid(ExecSpace_DefaultHost_t).name() << "\n";
-    std::cout << "MemorySpace_Host_t = " << typeid(MemorySpace_Host_t).name() << "\n";
-    std::cout << "MemorySpace_ofDefaultExec_t = " << typeid(MemorySpace_ofDefaultExec_t).name()
-              << "\n\n";
+    std::cout << "Default execution space = " << typeid(ExecSpace_Default_t).name() << "\n";
+    std::cout << "Default host execution space = " << typeid(ExecSpace_DefaultHost_t).name()
+              << "\n";
+    std::cout << "Default memory space = " << typeid(MemorySpace_ofDefaultExec_t).name() << "\n";
+    std::cout << "Default host memory space = " << typeid(MemorySpace_Host_t).name() << "\n";
+    std::cout << "\n";
 
     if (argc != 2) std::runtime_error("The code expects (only) an input file as argument");
     // Read the input file name from the command line
@@ -68,9 +69,6 @@ int main(int argc, char* argv[])
           std::cerr << "The output pressure does not match the expected result" << std::endl;
           return EXIT_FAILURE;
         }
-        std::cout << "meanPressure=" << meanPressure << "\n";
-        std::cout << "\tExpectedPressure=" << ExpectedPressure << "\n";
-        std::cout << "\tExpectedPressureTolerance=" << ExpectedPressureTolerance << "\n";
       }
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
           std::cerr << "\tMean pressure = " << meanPressure << "\n";
           std::cerr << "\tExpected pressure = " << ExpectedPressure << "\n";
           std::cerr << "\tExpected pressureTolerance = " << ExpectedPressureTolerance << "\n";
-          std::cerr << "effective contact area = " << effectiveContactAreaFraction << "\n";
+          std::cerr << "\tEffective contact area = " << effectiveContactAreaFraction << "\n";
           std::cerr << "\tExpected effective contact area fraction = "
                     << ExpectedEffectiveContactAreaFraction << "\n";
           std::cerr << "\tExpected effective contact area fraction tolerance = "

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char* argv[])
           std::cerr << "The output pressure does not match the expected result." << "\n";
           std::cerr << "\tMean pressure = " << meanPressure << "\n";
           std::cerr << "\tExpected pressure = " << ExpectedPressure << "\n";
-          std::cerr << "\tExpected pressureTolerance = " << ExpectedPressureTolerance << "\n";
+          std::cerr << "\tExpected pressureTolerance = " << ExpectedPressureTolerance << std::endl;
         }
         if (std::abs(effectiveContactAreaFraction - ExpectedEffectiveContactAreaFraction) >
             ExpectedEffectiveContactAreaFractionTolerance)
@@ -90,11 +90,11 @@ int main(int argc, char* argv[])
           std::cerr << "\tExpected effective contact area fraction = "
                     << ExpectedEffectiveContactAreaFraction << "\n";
           std::cerr << "\tExpected effective contact area fraction tolerance = "
-                    << ExpectedEffectiveContactAreaFractionTolerance << "\n";
+                    << ExpectedEffectiveContactAreaFractionTolerance << std::endl;
         }
 
         if (passedResultChecks)
-          std::cout << "All result checks passed" << "\n";
+          std::cout << "All result checks passed" << std::endl;
         else
           return EXIT_FAILURE;
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,12 +17,11 @@ int main(int argc, char* argv[])
   Kokkos::initialize(argc, argv);
   {
     std::cout << "-- Kokkos information --\n";
-    std::cout << "threads_in_use = " << ExecSpace_Default_t::concurrency() << "\n";
-    std::cout << "Default execution space = " << typeid(ExecSpace_Default_t).name() << "\n";
-    std::cout << "Default host execution space = " << typeid(ExecSpace_DefaultHost_t).name()
-              << "\n";
-    std::cout << "Default memory space = " << typeid(MemorySpace_ofDefaultExec_t).name() << "\n";
-    std::cout << "Default host memory space = " << typeid(MemorySpace_Host_t).name() << "\n";
+    std::cout << "Threads in use: " << ExecSpace_Default_t::concurrency() << "\n";
+    std::cout << "Default execution space: " << typeid(ExecSpace_Default_t).name() << "\n";
+    std::cout << "Default host execution space: " << typeid(ExecSpace_DefaultHost_t).name() << "\n";
+    std::cout << "Default memory space: " << typeid(MemorySpace_ofDefaultExec_t).name() << "\n";
+    std::cout << "Default host memory space: " << typeid(MemorySpace_Host_t).name() << "\n";
     std::cout << "\n";
 
     if (argc != 2) std::runtime_error("The code expects (only) an input file as argument");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,8 +79,8 @@ int main(int argc, char* argv[])
           std::cerr << "\tExpected pressureTolerance = " << ExpectedPressureTolerance << "\n";
           return EXIT_FAILURE;
         }
-        if (std::abs(effectiveContactAreaFraction - ExpectedEffectiveContactAreaFraction) >
-            ExpectedEffectiveContactAreaFractionTolerance)
+        else if (std::abs(effectiveContactAreaFraction - ExpectedEffectiveContactAreaFraction) >
+                 ExpectedEffectiveContactAreaFractionTolerance)
         {
           std::cerr << "The output effective contact area does not match the expected result."
                     << "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,20 +80,20 @@ int main(int argc, char* argv[])
             ExpectedEffectiveContactAreaFractionTolerance)
         {
           std::cerr << "The output effective contact area does not match the expected result."
-                    << std::endl;
-          std::cerr << "\tmeanPressure = " << meanPressure << "\n";
-          std::cerr << "\tExpectedPressure = " << ExpectedPressure << "\n";
-          std::cerr << "\tExpectedPressureTolerance = " << ExpectedPressureTolerance << "\n";
-          std::cerr << "effectiveContactArea = " << effectiveContactAreaFraction << "\n";
-          std::cerr << "\tExpectedEffectiveContactAreaFraction = "
-                  << ExpectedEffectiveContactAreaFraction << "\n";
-          std::cerr << "\tExpectedEffectiveContactAreaFractionTolerance = "
-                  << ExpectedEffectiveContactAreaFractionTolerance << std::endl;
+                    << "\n";
+          std::cerr << "\tMean pressure = " << meanPressure << "\n";
+          std::cerr << "\tExpected pressure = " << ExpectedPressure << "\n";
+          std::cerr << "\tExpected pressureTolerance = " << ExpectedPressureTolerance << "\n";
+          std::cerr << "effective contact area = " << effectiveContactAreaFraction << "\n";
+          std::cerr << "\tExpected effective contact area fraction = "
+                    << ExpectedEffectiveContactAreaFraction << "\n";
+          std::cerr << "\tExpected effective contact area fraction tolerance = "
+                    << ExpectedEffectiveContactAreaFractionTolerance << "\n";
           return EXIT_FAILURE;
         }
         else
         {
-          std::cout << "All result checks passed" << std::endl;
+          std::cout << "All result checks passed" << "\n";
         }
       }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,7 +73,10 @@ int main(int argc, char* argv[])
 
         if (std::abs(meanPressure - ExpectedPressure) > ExpectedPressureTolerance)
         {
-          std::cerr << "The output pressure does not match the expected result." << std::endl;
+          std::cerr << "The output pressure does not match the expected result." << "\n";
+          std::cerr << "\tMean pressure = " << meanPressure << "\n";
+          std::cerr << "\tExpected pressure = " << ExpectedPressure << "\n";
+          std::cerr << "\tExpected pressureTolerance = " << ExpectedPressureTolerance << "\n";
           return EXIT_FAILURE;
         }
         if (std::abs(effectiveContactAreaFraction - ExpectedEffectiveContactAreaFraction) >
@@ -81,9 +84,6 @@ int main(int argc, char* argv[])
         {
           std::cerr << "The output effective contact area does not match the expected result."
                     << "\n";
-          std::cerr << "\tMean pressure = " << meanPressure << "\n";
-          std::cerr << "\tExpected pressure = " << ExpectedPressure << "\n";
-          std::cerr << "\tExpected pressureTolerance = " << ExpectedPressureTolerance << "\n";
           std::cerr << "\tEffective contact area = " << effectiveContactAreaFraction << "\n";
           std::cerr << "\tExpected effective contact area fraction = "
                     << ExpectedEffectiveContactAreaFraction << "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,6 +68,10 @@ int main(int argc, char* argv[])
           std::cerr << "The output pressure does not match the expected result" << std::endl;
           return EXIT_FAILURE;
         }
+        else
+        {
+          std::cout << "All result checks passed" << std::endl;
+        }
       }
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,7 @@ int main(int argc, char* argv[])
       ryml::ConstNodeRef resultDescription = root["result_description"];
       if (!resultDescription.invalid())
       {
+        bool passedResultChecks = true;
         const double ExpectedPressure = Utils::get_double(resultDescription, "ExpectedPressure");
         const double ExpectedPressureTolerance =
             Utils::get_double(resultDescription, "ExpectedPressureTolerance");
@@ -73,15 +74,16 @@ int main(int argc, char* argv[])
 
         if (std::abs(meanPressure - ExpectedPressure) > ExpectedPressureTolerance)
         {
+          passedResultChecks = false;
           std::cerr << "The output pressure does not match the expected result." << "\n";
           std::cerr << "\tMean pressure = " << meanPressure << "\n";
           std::cerr << "\tExpected pressure = " << ExpectedPressure << "\n";
           std::cerr << "\tExpected pressureTolerance = " << ExpectedPressureTolerance << "\n";
-          return EXIT_FAILURE;
         }
-        else if (std::abs(effectiveContactAreaFraction - ExpectedEffectiveContactAreaFraction) >
-                 ExpectedEffectiveContactAreaFractionTolerance)
+        if (std::abs(effectiveContactAreaFraction - ExpectedEffectiveContactAreaFraction) >
+            ExpectedEffectiveContactAreaFractionTolerance)
         {
+          passedResultChecks = false;
           std::cerr << "The output effective contact area does not match the expected result."
                     << "\n";
           std::cerr << "\tEffective contact area = " << effectiveContactAreaFraction << "\n";
@@ -89,12 +91,12 @@ int main(int argc, char* argv[])
                     << ExpectedEffectiveContactAreaFraction << "\n";
           std::cerr << "\tExpected effective contact area fraction tolerance = "
                     << ExpectedEffectiveContactAreaFractionTolerance << "\n";
-          return EXIT_FAILURE;
         }
-        else
-        {
+
+        if (passedResultChecks)
           std::cout << "All result checks passed" << "\n";
-        }
+        else
+          return EXIT_FAILURE;
       }
     }
   }

--- a/src/mirco_utils.h
+++ b/src/mirco_utils.h
@@ -5,7 +5,6 @@
 #include <ryml_std.hpp>
 #include <string>
 
-
 namespace MIRCO
 {
   namespace Utils

--- a/src/mirco_warmstart.cpp
+++ b/src/mirco_warmstart.cpp
@@ -1,7 +1,5 @@
 #include "mirco_warmstart.h"
 
-#include <algorithm>
-
 namespace MIRCO
 {
   ViewVector_d Warmstart(


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Why is this change required? What problem does it solve?
-->
This change fixes https://github.com/imcs-compsim/MIRCO/issues/121.

`CMakeLists.txt` now checks whether one of the backends which offload compilation to a specific compiler is enabled (mostly GPU backends). If so, it adds rapidyaml as an external project (`ExternalProject_Add`) and compiles it separately from the rest of MIRCO with the CXX compiler `MIRCO_HOST_CXX_COMPILER`, to make sure it compiles on host. Else if using a host-side backend like Serial or OpenMP, `fetch_content()` is used.

Additionally, I have extended the docker file installation and presets in *preparation* for a CI test with CUDA backend (see https://github.com/imcs-compsim/MIRCO/issues/126).

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests:
-->
* Closes https://github.com/imcs-compsim/MIRCO/issues/121
* Precedes https://github.com/imcs-compsim/MIRCO/issues/126

## How Has This Been Tested?
<!--
Feel free to provide further information if useful or necessary.
-->
I have tested this on my machine and it works with CUDA backend. I have not tested it with other GPU backends.

## Interested Parties / Possible Reviewers
<!--
If there's any developer, who you think should be looped in on this pull request, feel free to @mention them here.
-->
@mayrmt