### PR TITLE
Enable compilation with clangcuda++ and enable kokkoscuda build tests [Related to 4C]

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -82,3 +82,34 @@ jobs:
           ninja -j 12
           ctest --output-on-failure
           cd ..&&rm -rf build_kokkosopenmp
+
+  mirco-buildtest-kokkoscuda:
+    name: mirco_buildtest_kokkoscuda
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/philipoesterlepekrun/mirco-kokkos-dependencies:latest
+
+    env:
+      CTEST_FAIL_ON_WARNING: "1"
+
+    steps:
+      - name: Checkout code with submodules
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          path: mirco-src
+          fetch-depth: 0  # Necessary for full git history and tags
+
+      - name: Build and test
+        run: |
+          mkdir mirco-build_kokkoscuda
+          cd mirco-build_kokkoscuda
+          cmake --preset=docker_container_kokkoscuda ../mirco-src/
+          ninja -j 1
+          #ctest --output-on-failure
+          rm -rf *
+          cmake --preset=docker_container_kokkoscuda_clangcuda++ ../mirco-src/
+          ninja -j 1
+          #ctest --output-on-failure
+          cd ..&&rm -rf build_kokkosopenmp

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/philipoesterlepekrun/mirco-kokkos-dependencies:latest
+      image: ghcr.io/imcs-compsim/mirco-dependencies:latest
 
     env:
       CTEST_FAIL_ON_WARNING: "1"
@@ -54,14 +54,14 @@ jobs:
           cmake --preset=docker_container_kokkosserial ../mirco-src/
           ninja -j 12
           ctest --output-on-failure
-          cd ..&&rm -rf build_kokkosserial
+          cd ..&&rm -rf mirco-build_kokkosserial
 
   mirco-test-kokkosopenmp:
     name: mirco_test_kokkosopenmp
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/philipoesterlepekrun/mirco-kokkos-dependencies:latest
+      image: ghcr.io/imcs-compsim/mirco-dependencies:latest
 
     env:
       CTEST_FAIL_ON_WARNING: "1"
@@ -81,14 +81,14 @@ jobs:
           cmake --preset=docker_container_kokkosopenmp ../mirco-src/
           ninja -j 12
           ctest --output-on-failure
-          cd ..&&rm -rf build_kokkosopenmp
+          cd ..&&rm -rf mirco-build_kokkosopenmp
 
   mirco-buildtest-kokkoscuda:
     name: mirco_buildtest_kokkoscuda
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/philipoesterlepekrun/mirco-kokkos-dependencies:latest
+      image: ghcr.io/imcs-compsim/mirco-dependencies:latest
 
     env:
       CTEST_FAIL_ON_WARNING: "1"
@@ -101,7 +101,7 @@ jobs:
           path: mirco-src
           fetch-depth: 0  # Necessary for full git history and tags
 
-      - name: Build and test
+      - name: Build (without testing)
         run: |
           mkdir mirco-build_kokkoscuda
           cd mirco-build_kokkoscuda
@@ -112,4 +112,4 @@ jobs:
           cmake --preset=docker_container_kokkoscuda_clangcuda++ ../mirco-src/
           ninja -j 1
           #ctest --output-on-failure
-          cd ..&&rm -rf build_kokkosopenmp
+          cd ..&&rm -rf mirco-build_kokkosopenmp

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,50 @@
+name: Docker
+
+on:
+  pull_request:
+    paths:
+      - "docker/**"
+      - "dependencies/**"
+      - ".github/workflows/docker.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docker/**"
+      - "dependencies/**"
+      - ".github/workflows/docker.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: imcs-compsim/mirco-dependencies
+
+jobs:
+  docker-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish on main branch, and build without publishing for a PR
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/dependencies/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,8 +110,8 @@ if(MIRCO_CLANGCUDA)
 endif()
 
 # A function to set the necessary properties/definitions so a target can be compiled with clangcuda++
-# `compile_type` can be either CLANGCUDA_HOST or CLANGCUDA_DEVICE
-function(mirco_configure_clangcuda_target target_name compile_type)
+# `compile_mode` can be either CLANGCUDA_MODE_HOST or CLANGCUDA_MODE_DEVICE
+function(mirco_configure_clangcuda_target target_name compile_mode)
   set_target_properties("${target_name}" PROPERTIES
     CXX_COMPILER_LAUNCHER ""
     C_COMPILER_LAUNCHER ""
@@ -121,23 +121,22 @@ function(mirco_configure_clangcuda_target target_name compile_type)
   )
 
   target_compile_definitions("${target_name}" PRIVATE
-    compile_type
+    ${compile_mode}
   )
 endfunction()
 
 option(MIRCO_ENABLE_VISUALIZATIONEXPORT "Enable exporting the results for visualization. This requires VTK, either explicitly provided through VTK_PATH, or from an upstream project." OFF)
 if(MIRCO_ENABLE_VISUALIZATIONEXPORT)
+  if(MIRCO_CLANGCUDA)
+    message(FATAL "MIRCO_ENABLE_VISUALIZATIONEXPORT with MIRCO_CLANGCUDA is currently not supported. Please use nvcc_wrapper.")
+  endif()
+
   # If user provided a prefix, help CMake find VTK there
   if(DEFINED VTK_PATH)
     set(CMAKE_PREFIX_PATH ${VTK_PATH} ${CMAKE_PREFIX_PATH})
   endif()
 
-  find_package(VTK QUIET COMPONENTS CommonCore CommonDataModel IOCore IOXML REQUIRED)
-
-  if(NOT VTK_FOUND)
-    message(WARNING "MIRCO_ENABLE_VISUALIZATIONEXPORT is ON, but VTK could not be found!")
-    set(MIRCO_WITH_VTK OFF CACHE BOOL "" FORCE)
-  endif()
+  find_package(VTK REQUIRED COMPONENTS CommonCore CommonDataModel IOCore IOXML REQUIRED)
 endif()
 
 # File(s) which need(s) Kokkos-Kernels
@@ -146,7 +145,7 @@ add_library(mirco_needKK
   )
 target_link_libraries(mirco_needKK PRIVATE Kokkos::kokkos KokkosKernels::kokkoskernels)
 if(MIRCO_CLANGCUDA)
-  mirco_configure_clangcuda_target(mirco_needKK CLANGCUDA_DEVICE)
+  mirco_configure_clangcuda_target(mirco_needKK CLANGCUDA_MODE_DEVICE)
 endif()
 
 # Compile mirco library
@@ -159,20 +158,28 @@ add_library(mirco_core
   )
 target_link_libraries(mirco_core PRIVATE mirco_needKK Kokkos::kokkos)
 if(MIRCO_CLANGCUDA)
-  mirco_configure_clangcuda_target(mirco_core CLANGCUDA_DEVICE)
+  mirco_configure_clangcuda_target(mirco_core CLANGCUDA_MODE_DEVICE)
 endif()
 
 if(MIRCO_ENABLE_VISUALIZATIONEXPORT)
-  target_sources(mirco_core PRIVATE src/mirco_exportvisualization.cpp)
-  target_link_libraries(mirco_core PRIVATE
+  add_library(mirco_vis
+    src/mirco_exportvisualization.cpp
+    )
+  target_link_libraries(mirco_vis PRIVATE
+    Kokkos::kokkos
     VTK::CommonCore
     VTK::CommonDataModel
     VTK::IOCore
     VTK::IOXML
   )
   if(MIRCO_CLANGCUDA)
-    mirco_configure_clangcuda_target(mirco_core CLANGCUDA_DEVICE)
+    mirco_configure_clangcuda_target(mirco_vis CLANGCUDA_MODE_HOST)
   endif()
+
+  #target_sources(mirco_core PRIVATE src/mirco_exportvisualization.cpp)
+  target_link_libraries(mirco_core PRIVATE
+    mirco_vis
+  )
 endif()
 
 add_library(mirco_topology
@@ -181,7 +188,7 @@ add_library(mirco_topology
   )
 target_link_libraries(mirco_topology PRIVATE Kokkos::kokkos)
 if(MIRCO_CLANGCUDA)
-  mirco_configure_clangcuda_target(mirco_core CLANGCUDA_DEVICE)
+  mirco_configure_clangcuda_target(mirco_topology CLANGCUDA_MODE_DEVICE)
 endif()
 
 add_library(mirco_shapefactors
@@ -193,13 +200,13 @@ add_library(mirco_inputparameters
   )
 target_link_libraries(mirco_inputparameters PRIVATE mirco_topology mirco_shapefactors Kokkos::kokkos)
 if(MIRCO_CLANGCUDA)
-  mirco_configure_clangcuda_target(mirco_inputparameters CLANGCUDA_HOST)
+  mirco_configure_clangcuda_target(mirco_inputparameters CLANGCUDA_MODE_HOST)
 endif()
 
-option(RYML_IN_MIRCO "Find ryml in MIRCO project. If set to OFF, use the ryml installation from an upstream project" OFF)
+option(RYML_IN_MIRCO "Find rapidyaml (ryml) in MIRCO project. If set to OFF, use the ryml installation from an upstream project" OFF)
 
 if(RYML_IN_MIRCO)
-  message(STATUS "Building ryml within MIRCO project.")
+  message(STATUS "Building rapidyaml within MIRCO project.")
   if((NOT MIRCO_CLANGCUDA) AND (Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP OR Kokkos_ENABLE_SYCL OR Kokkos_ENABLE_OPENMPTARGET))
     # Compile rapidyaml (ryml) separately to avoid conflicts with device-side/offloaded compilers (e.g. nvcc_wrapper). clangcuda++ does not have this issue
     message(STATUS "Building rapidyaml using MIRCO_HOST_CXX_COMPILER")
@@ -215,6 +222,7 @@ if(RYML_IN_MIRCO)
       GIT_TAG 47ec2fa184209687c20fd5bc05621e1cb1200311
       INSTALL_DIR ${RYML_INSTALL_DIR}
       CMAKE_ARGS
+        -Wno-dev # Suppress developer warnings
         -DCMAKE_CXX_COMPILER=${MIRCO_HOST_CXX_COMPILER}
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
@@ -286,7 +294,7 @@ add_library(mirco_inputparameters_yaml
   )
 target_link_libraries(mirco_inputparameters_yaml PRIVATE mirco_inputparameters mirco_utils Kokkos::kokkos)
 if(MIRCO_CLANGCUDA)
-  mirco_configure_clangcuda_target(mirco_inputparameters_yaml CLANGCUDA_HOST)
+  mirco_configure_clangcuda_target(mirco_inputparameters_yaml CLANGCUDA_MODE_HOST)
 endif()
 
 add_library(mirco_lib INTERFACE)
@@ -308,7 +316,7 @@ target_compile_definitions(mirco_core PUBLIC
 add_executable(mirco src/main.cpp)
 target_link_libraries(mirco PUBLIC mirco::mirco_lib mirco_inputparameters_yaml mirco_utils Kokkos::kokkos)
 if(MIRCO_CLANGCUDA)
-  mirco_configure_clangcuda_target(mirco CLANGCUDA_DEVICE)
+  mirco_configure_clangcuda_target(mirco CLANGCUDA_MODE_DEVICE)
 endif()
 
 # Compile the flatMirco utility
@@ -316,15 +324,28 @@ if(MIRCO_ENABLE_FLAT)
   add_executable(flatMirco src/main_flat.cpp)
   target_link_libraries(flatMirco PUBLIC mirco_core mirco_topology mirco_shapefactors Kokkos::kokkos KokkosKernels::kokkoskernels)
   if(MIRCO_CLANGCUDA)
-    mirco_configure_clangcuda_target(flatMirco CLANGCUDA_DEVICE)
+    mirco_configure_clangcuda_target(flatMirco CLANGCUDA_MODE_DEVICE)
   endif()
 endif()
 
 # Install mirco (to be used as a library by other codes)
-install(TARGETS mirco_lib mirco_needKK mirco_core mirco_topology mirco_inputparameters mirco_shapefactors
+set(MIRCO_INSTALL_TARGETS
+  mirco_lib
+  mirco_needKK
+  mirco_core
+  mirco_topology
+  mirco_inputparameters
+  mirco_shapefactors
+)
+
+if(MIRCO_ENABLE_VISUALIZATIONEXPORT)
+  list(APPEND MIRCO_INSTALL_TARGETS mirco_vis)
+endif()
+
+install(TARGETS ${MIRCO_INSTALL_TARGETS}
   EXPORT mirco_libTargets
   ARCHIVE LIBRARY PUBLIC_HEADER
-  )
+)
 
 install(EXPORT mirco_libTargets
   NAMESPACE mirco::
@@ -355,7 +376,7 @@ if(GTEST_IN_MIRCO)
     )
   target_link_libraries(tests PUBLIC mirco::mirco_lib mirco_inputparameters_yaml mirco_utils mirco_shapefactors gtest Kokkos::kokkos)
   if(MIRCO_CLANGCUDA)
-    mirco_configure_clangcuda_target(tests CLANGCUDA_DEVICE)
+    mirco_configure_clangcuda_target(tests CLANGCUDA_MODE_DEVICE)
   endif()
 
   # Copy tests/unittests/data folder to the build dir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,30 @@ if(KOKKOS_KERNELS_IN_MIRCO)
   endif()
 endif()
 
+option(MIRCO_CLANGCUDA "Enable the relevant CMake compile definitions needed to use clangcuda++ as the compiler. Alternatively, one can use Kokkos' nvcc_wrapper." OFF)
+
+if(MIRCO_CLANGCUDA)
+  set(CMAKE_CXX_COMPILER_LAUNCHER "" CACHE STRING "" FORCE)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "")
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "")
+endif()
+
+# A function to set the necessary properties/definitions so a target can be compiled with clangcuda++
+# `compile_type` can be either CLANGCUDA_HOST or CLANGCUDA_DEVICE
+function(mirco_configure_clangcuda_target target_name compile_type)
+  set_target_properties("${target_name}" PROPERTIES
+    CXX_COMPILER_LAUNCHER ""
+    C_COMPILER_LAUNCHER ""
+    CUDA_COMPILER_LAUNCHER ""
+    RULE_LAUNCH_COMPILE ""
+    RULE_LAUNCH_LINK ""
+  )
+
+  target_compile_definitions("${target_name}" PRIVATE
+    compile_type
+  )
+endfunction()
+
 option(MIRCO_ENABLE_VISUALIZATIONEXPORT "Enable exporting the results for visualization. This requires VTK, either explicitly provided through VTK_PATH, or from an upstream project." OFF)
 if(MIRCO_ENABLE_VISUALIZATIONEXPORT)
   # If user provided a prefix, help CMake find VTK there
@@ -121,6 +145,9 @@ add_library(mirco_needKK
   src/mirco_nonlinearsolver.cpp
   )
 target_link_libraries(mirco_needKK PRIVATE Kokkos::kokkos KokkosKernels::kokkoskernels)
+if(MIRCO_CLANGCUDA)
+  mirco_configure_clangcuda_target(mirco_needKK CLANGCUDA_DEVICE)
+endif()
 
 # Compile mirco library
 add_library(mirco_core
@@ -131,6 +158,9 @@ add_library(mirco_core
   src/mirco_warmstart.cpp
   )
 target_link_libraries(mirco_core PRIVATE mirco_needKK Kokkos::kokkos)
+if(MIRCO_CLANGCUDA)
+  mirco_configure_clangcuda_target(mirco_core CLANGCUDA_DEVICE)
+endif()
 
 if(MIRCO_ENABLE_VISUALIZATIONEXPORT)
   target_sources(mirco_core PRIVATE src/mirco_exportvisualization.cpp)
@@ -140,6 +170,9 @@ if(MIRCO_ENABLE_VISUALIZATIONEXPORT)
     VTK::IOCore
     VTK::IOXML
   )
+  if(MIRCO_CLANGCUDA)
+    mirco_configure_clangcuda_target(mirco_core CLANGCUDA_DEVICE)
+  endif()
 endif()
 
 add_library(mirco_topology
@@ -147,6 +180,9 @@ add_library(mirco_topology
   src/mirco_topologyutilities.cpp
   )
 target_link_libraries(mirco_topology PRIVATE Kokkos::kokkos)
+if(MIRCO_CLANGCUDA)
+  mirco_configure_clangcuda_target(mirco_core CLANGCUDA_DEVICE)
+endif()
 
 add_library(mirco_shapefactors
   src/mirco_shapefactors.cpp
@@ -156,13 +192,16 @@ add_library(mirco_inputparameters
   src/mirco_inputparameters.cpp
   )
 target_link_libraries(mirco_inputparameters PRIVATE mirco_topology mirco_shapefactors Kokkos::kokkos)
+if(MIRCO_CLANGCUDA)
+  mirco_configure_clangcuda_target(mirco_inputparameters CLANGCUDA_HOST)
+endif()
 
 option(RYML_IN_MIRCO "Find ryml in MIRCO project. If set to OFF, use the ryml installation from an upstream project" OFF)
 
 if(RYML_IN_MIRCO)
   message(STATUS "Building ryml within MIRCO project.")
-  if(Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP OR Kokkos_ENABLE_SYCL OR Kokkos_ENABLE_OPENMPTARGET)
-    # Compile rapidyaml (ryml) separately to avoid conflicts with device-side/offloaded compilers (e.g. nvcc_wrapper)
+  if((NOT MIRCO_CLANGCUDA) AND (Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP OR Kokkos_ENABLE_SYCL OR Kokkos_ENABLE_OPENMPTARGET))
+    # Compile rapidyaml (ryml) separately to avoid conflicts with device-side/offloaded compilers (e.g. nvcc_wrapper). clangcuda++ does not have this issue
     message(STATUS "Building rapidyaml using MIRCO_HOST_CXX_COMPILER")
     include(ExternalProject)
     set(RYML_INSTALL_DIR ${CMAKE_BINARY_DIR}/extern/ryml)
@@ -212,12 +251,12 @@ if(RYML_IN_MIRCO)
       ALWAYS TRUE
     )
   else()
-    # Everything is compiled on host; fetch rapidyaml directly
+    # Fetch rapidyaml directly
     message(STATUS "Fetching rapidyaml...")
     include(FetchContent)
-    
+
     set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS ON CACHE BOOL "" FORCE) # Suppress developer warnings from ryml
-    
+
     FetchContent_Declare(rapidyaml
       GIT_REPOSITORY https://github.com/biojppm/rapidyaml.git
       GIT_TAG 47ec2fa184209687c20fd5bc05621e1cb1200311
@@ -246,6 +285,9 @@ add_library(mirco_inputparameters_yaml
   src/mirco_inputparameters_yaml.cpp
   )
 target_link_libraries(mirco_inputparameters_yaml PRIVATE mirco_inputparameters mirco_utils Kokkos::kokkos)
+if(MIRCO_CLANGCUDA)
+  mirco_configure_clangcuda_target(mirco_inputparameters_yaml CLANGCUDA_HOST)
+endif()
 
 add_library(mirco_lib INTERFACE)
 target_link_libraries(mirco_lib INTERFACE mirco_needKK mirco_core mirco_topology mirco_inputparameters)
@@ -265,11 +307,17 @@ target_compile_definitions(mirco_core PUBLIC
 # Compile mirco itself
 add_executable(mirco src/main.cpp)
 target_link_libraries(mirco PUBLIC mirco::mirco_lib mirco_inputparameters_yaml mirco_utils Kokkos::kokkos)
+if(MIRCO_CLANGCUDA)
+  mirco_configure_clangcuda_target(mirco CLANGCUDA_DEVICE)
+endif()
 
 # Compile the flatMirco utility
 if(MIRCO_ENABLE_FLAT)
   add_executable(flatMirco src/main_flat.cpp)
   target_link_libraries(flatMirco PUBLIC mirco_core mirco_topology mirco_shapefactors Kokkos::kokkos KokkosKernels::kokkoskernels)
+  if(MIRCO_CLANGCUDA)
+    mirco_configure_clangcuda_target(flatMirco CLANGCUDA_DEVICE)
+  endif()
 endif()
 
 # Install mirco (to be used as a library by other codes)
@@ -306,6 +354,9 @@ if(GTEST_IN_MIRCO)
     tests/unittests/test.cpp
     )
   target_link_libraries(tests PUBLIC mirco::mirco_lib mirco_inputparameters_yaml mirco_utils mirco_shapefactors gtest Kokkos::kokkos)
+  if(MIRCO_CLANGCUDA)
+    mirco_configure_clangcuda_target(tests CLANGCUDA_DEVICE)
+  endif()
 
   # Copy tests/unittests/data folder to the build dir
   add_custom_command(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,10 +127,6 @@ endfunction()
 
 option(MIRCO_ENABLE_VISUALIZATIONEXPORT "Enable exporting the results for visualization. This requires VTK, either explicitly provided through VTK_PATH, or from an upstream project." OFF)
 if(MIRCO_ENABLE_VISUALIZATIONEXPORT)
-  if(MIRCO_CLANGCUDA)
-    message(FATAL "MIRCO_ENABLE_VISUALIZATIONEXPORT with MIRCO_CLANGCUDA is currently not supported. Please use nvcc_wrapper.")
-  endif()
-
   # If user provided a prefix, help CMake find VTK there
   if(DEFINED VTK_PATH)
     set(CMAKE_PREFIX_PATH ${VTK_PATH} ${CMAKE_PREFIX_PATH})
@@ -162,23 +158,19 @@ if(MIRCO_CLANGCUDA)
 endif()
 
 if(MIRCO_ENABLE_VISUALIZATIONEXPORT)
-  add_library(mirco_vis
-    src/mirco_exportvisualization.cpp
+  add_library(mirco_vis_vtk
+    src/mirco_exportvisualization_vtk.cpp
     )
-  target_link_libraries(mirco_vis PRIVATE
-    Kokkos::kokkos
+  target_link_libraries(mirco_vis_vtk PRIVATE
     VTK::CommonCore
     VTK::CommonDataModel
     VTK::IOCore
     VTK::IOXML
   )
-  if(MIRCO_CLANGCUDA)
-    mirco_configure_clangcuda_target(mirco_vis CLANGCUDA_MODE_HOST)
-  endif()
 
-  #target_sources(mirco_core PRIVATE src/mirco_exportvisualization.cpp)
+  target_sources(mirco_core PRIVATE src/mirco_exportvisualization.cpp)
   target_link_libraries(mirco_core PRIVATE
-    mirco_vis
+    mirco_vis_vtk
   )
 endif()
 
@@ -337,11 +329,9 @@ set(MIRCO_INSTALL_TARGETS
   mirco_inputparameters
   mirco_shapefactors
 )
-
 if(MIRCO_ENABLE_VISUALIZATIONEXPORT)
-  list(APPEND MIRCO_INSTALL_TARGETS mirco_vis)
+  list(APPEND MIRCO_INSTALL_TARGETS mirco_vis_vtk)
 endif()
-
 install(TARGETS ${MIRCO_INSTALL_TARGETS}
   EXPORT mirco_libTargets
   ARCHIVE LIBRARY PUBLIC_HEADER

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,7 +15,8 @@
         "RYML_IN_MIRCO": "ON",
         "GTEST_IN_MIRCO": "ON",
         "MIRCO_ENABLE_FLAT": "OFF",
-        "MIRCO_ENABLE_VISUALIZATIONEXPORT": "OFF"
+        "MIRCO_ENABLE_VISUALIZATIONEXPORT": "OFF",
+        "CMAKE_POSITION_INDEPENDENT_CODE": "ON"
       }
     },
     {
@@ -51,11 +52,29 @@
       ],
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "/opt/mirco-dependencies/kokkos/bin/nvcc_wrapper",
-        "MIRCO_HOST_CXX_COMPILER": "g++-12",
+        "MIRCO_HOST_CXX_COMPILER": "g++",
+        "MIRCO_CLANGCUDA": "OFF",
+        "CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE": "PRE_TEST",
         "KOKKOS_PATH": "/opt/mirco-dependencies/kokkos_install_cuda",
         "KOKKOS_KERNELS_PATH": "/opt/mirco-dependencies/kokkos-kernels_install_cuda",
         "MIRCO_ENABLE_FLAT": "ON",
         "MIRCO_ENABLE_VISUALIZATIONEXPORT": "ON"
+      }
+    },
+    {
+      "name": "docker_container_kokkoscuda_clangcuda++",
+      "displayName": "Release build using Kokkos with CUDA backend and the clangcuda++ wrapper as the compiler for CI/CD testing in a docker container",
+      "inherits": [
+        ".base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "${sourceDir}/clangcuda++",
+        "MIRCO_CLANGCUDA": "ON",
+        "CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE": "PRE_TEST",
+        "KOKKOS_PATH": "/opt/mirco-dependencies/kokkos_install_cuda",
+        "KOKKOS_KERNELS_PATH": "/opt/mirco-dependencies/kokkos-kernels_install_cuda",
+        "MIRCO_ENABLE_FLAT": "ON",
+        "MIRCO_ENABLE_VISUALIZATIONEXPORT": "OFF"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -74,7 +74,7 @@
         "KOKKOS_PATH": "/opt/mirco-dependencies/kokkos_install_cuda",
         "KOKKOS_KERNELS_PATH": "/opt/mirco-dependencies/kokkos-kernels_install_cuda",
         "MIRCO_ENABLE_FLAT": "ON",
-        "MIRCO_ENABLE_VISUALIZATIONEXPORT": "OFF"
+        "MIRCO_ENABLE_VISUALIZATIONEXPORT": "ON"
       }
     },
     {

--- a/clangcuda++
+++ b/clangcuda++
@@ -1,28 +1,21 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-# This file is part of 4C multiphysics licensed under the
-# GNU Lesser General Public License v3.0 or later.
+# This is a compiler wrapper around clang++ for building a project which uses Kokkos with the Cuda backend enabled, due to issues with nvcc and the nvcc_wrapper provided by Kokkos.
 #
-# See the LICENSE.md file in the top-level for license information.
-#
-# SPDX-License-Identifier: LGPL-3.0-or-later
-
-# This is a compiler wrapper around clang++ for building 4C when using a Kokkos installation with the Cuda backend enabled, due to issues with nvcc and the nvcc_wrapper provided by Kokkos.
-#
-# When relevant, this wrapper should be used as the CXX_COMPILER or OMPI_CXX backend in combination with CMake flags to signal which targets (or objects) should be compiled for CUDA device, CUDA host-only, or normal (non-CUDA) C++.
+# When relevant, this wrapper should be used as the CXX_COMPILER or OMPI_CXX backend in combination with CMake flags to signal which targets (or objects) should be compiled for CUDA device (CLANGCUDA_MODE_DEVICE), CUDA host-only (CLANGCUDA_MODE_HOST), or normal (non-CUDA) C++.
 #
 # The following environment variables can be used to override the defaults:
-# - CLANGCUDA_CLANG: path to clang++
+# - CLANGCUDA_CLANG_PATH: path to clang++
 # - CLANGCUDA_CUDA_PATH: path to the CUDA toolkit
 # - CLANGCUDA_ARCH: GPU architecture to target (default is sm_90)
 # - CLANGCUDA_LOG: optional path to a log file for recording final commands
 
-clang="${CLANGCUDA_CLANG:-/bin/clang++}"
+clang="${CLANGCUDA_CLANG_PATH:-/bin/clang++}"
 cuda_path="${CLANGCUDA_CUDA_PATH:-${CUDA_HOME:-/usr/local/cuda}}"
 
 compile=0
-cuda_host_only=0
-cuda_device=0
+mode_cuda_host=0
+mode_cuda_device=0
 arch="${CLANGCUDA_ARCH:-sm_90}"
 
 args=()
@@ -41,12 +34,12 @@ for arg in "$@"; do
       ;;
 
     -DCLANGCUDA_MODE_HOST)
-      cuda_host_only=1
+      mode_cuda_host=1
       args+=("$arg")
       ;;
 
     -DCLANGCUDA_MODE_DEVICE)
-      cuda_device=1
+      mode_cuda_device=1
       args+=("$arg")
       ;;
 
@@ -75,7 +68,7 @@ for arg in "$@"; do
 done
 
 # Sanity check
-if [[ "$cuda_host_only" == "1" && "$cuda_device" == "1" ]]; then
+if [[ "$mode_cuda_host" == "1" && "$mode_cuda_device" == "1" ]]; then
   has_explicit_device=0
   for arg in "$@"; do
     if [[ "$arg" == "-DCLANGCUDA_MODE_DEVICE" ]]; then
@@ -90,7 +83,7 @@ if [[ "$cuda_host_only" == "1" && "$cuda_device" == "1" ]]; then
   fi
 fi
 
-if [[ "$compile" == "1" && "$cuda_host_only" == "1" ]]; then
+if [[ "$compile" == "1" && "$mode_cuda_host" == "1" ]]; then
   final=(
     "$clang"
     -x cuda
@@ -100,7 +93,7 @@ if [[ "$compile" == "1" && "$cuda_host_only" == "1" ]]; then
     -Wno-unknown-cuda-version
     "${args[@]}"
   )
-elif [[ "$compile" == "1" && "$cuda_device" == "1" ]]; then
+elif [[ "$compile" == "1" && "$mode_cuda_device" == "1" ]]; then
   final=(
     "$clang"
     -x cuda

--- a/clangcuda++
+++ b/clangcuda++
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# This is a compiler wrapper around clang++ for building 4C when using a Kokkos installation with the Cuda backend enabled, due to issues with nvcc and the nvcc_wrapper provided by Kokkos.
+#
+# When relevant, this wrapper should be used as the CXX_COMPILER or OMPI_CXX backend in combination with CMake flags to signal which targets (or objects) should be compiled for CUDA device, CUDA host-only, or normal (non-CUDA) C++.
+#
+# The following environment variables can be used to override the defaults:
+# - CLANGCUDA_CLANG: path to clang++
+# - CLANGCUDA_CUDA_PATH: path to the CUDA toolkit
+# - CLANGCUDA_ARCH: GPU architecture to target (default is sm_90)
+# - CLANGCUDA_LOG: optional path to a log file for recording final commands
+
+clang="${CLANGCUDA_CLANG:-/bin/clang++}"
+cuda_path="${CLANGCUDA_CUDA_PATH:-${CUDA_HOME:-/usr/local/cuda}}"
+
+compile=0
+cuda_host_only=0
+cuda_device=0
+arch="${CLANGCUDA_ARCH:-sm_90}"
+
+args=()
+skip_next_x=0
+
+for arg in "$@"; do
+  if [[ "$skip_next_x" == "1" ]]; then
+    skip_next_x=0
+    continue
+  fi
+
+  case "$arg" in
+    -c)
+      compile=1
+      args+=("$arg")
+      ;;
+
+    -DCLANGCUDA_MODE_HOST)
+      cuda_host_only=1
+      args+=("$arg")
+      ;;
+
+    -DCLANGCUDA_MODE_DEVICE)
+      cuda_device=1
+      args+=("$arg")
+      ;;
+
+    -extended-lambda|--extended-lambda|--expt-extended-lambda|-expt-extended-lambda)
+      ;;
+
+    -expt-relaxed-constexpr|--expt-relaxed-constexpr)
+      ;;
+
+    -arch=sm_*|--cuda-gpu-arch=sm_*)
+      # Ignore incoming arch flags. Wrapper decides from CLANGCUDA_ARCH or default.
+      ;;
+
+    -ccbin=*|--compiler-bindir=*)
+      ;;
+
+    -x)
+      # Drop incoming language override and the following language token.
+      skip_next_x=1
+      ;;
+
+    *)
+      args+=("$arg")
+      ;;
+  esac
+done
+
+# Sanity check
+if [[ "$cuda_host_only" == "1" && "$cuda_device" == "1" ]]; then
+  has_explicit_device=0
+  for arg in "$@"; do
+    if [[ "$arg" == "-DCLANGCUDA_MODE_DEVICE" ]]; then
+      has_explicit_device=1
+      break
+    fi
+  done
+
+  if [[ "$has_explicit_device" == "1" ]]; then
+    echo "clangcuda++ wrapper error: both CLANGCUDA_MODE_HOST and CLANGCUDA_MODE_DEVICE were set" >&2
+    exit 1
+  fi
+fi
+
+if [[ "$compile" == "1" && "$cuda_host_only" == "1" ]]; then
+  final=(
+    "$clang"
+    -x cuda
+    --cuda-host-only
+    --cuda-path="$cuda_path"
+    --cuda-gpu-arch="$arch"
+    -Wno-unknown-cuda-version
+    "${args[@]}"
+  )
+elif [[ "$compile" == "1" && "$cuda_device" == "1" ]]; then
+  final=(
+    "$clang"
+    -x cuda
+    --cuda-path="$cuda_path"
+    --cuda-gpu-arch="$arch"
+    -Wno-unknown-cuda-version
+    "${args[@]}"
+  )
+else
+  final=(
+    "$clang"
+    -Wno-unknown-cuda-version
+    "${args[@]}"
+  )
+fi
+
+if [[ -n "$CLANGCUDA_LOG" ]]; then
+  printf '%q ' "${final[@]}" >> "$CLANGCUDA_LOG"
+  printf '\n' >> "$CLANGCUDA_LOG"
+fi
+
+exec "${final[@]}"

--- a/dependencies/kokkos-kernels/install.sh
+++ b/dependencies/kokkos-kernels/install.sh
@@ -24,7 +24,7 @@ cd .. && mkdir kokkos-kernels_build && cd kokkos-kernels_build
 # Build and install with Serial backend
 $CMAKE_COMMAND \
   -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
-  -D CMAKE_CXX_STANDARD:STRING="17" \
+  -D CMAKE_CXX_STANDARD:STRING="20" \
   -D CMAKE_CXX_COMPILER=g++ \
   -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos-kernels_install_serial \
   -D BUILD_SHARED_LIBS:BOOL=OFF \
@@ -36,7 +36,7 @@ $CMAKE_COMMAND \
   \
   -D Kokkos_ENABLE_SERIAL=ON \
   \
-  ../kokkos-kernels
+../kokkos-kernels
 make -j${NPROCS} install
 
 # Clean build dir
@@ -45,7 +45,7 @@ rm -rf *
 # Build and install with OpenMP backend
 $CMAKE_COMMAND \
   -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
-  -D CMAKE_CXX_STANDARD:STRING="17" \
+  -D CMAKE_CXX_STANDARD:STRING="20" \
   -D CMAKE_CXX_COMPILER=g++ \
   -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos-kernels_install_openmp \
   -D BUILD_SHARED_LIBS:BOOL=OFF \
@@ -57,30 +57,33 @@ $CMAKE_COMMAND \
   \
   -D Kokkos_ENABLE_OPENMP=ON \
   \
-  ../kokkos-kernels
+../kokkos-kernels
 make -j${NPROCS} install
 
 # Clean build dir
 rm -rf *
 
 # Build and install with Serial+CUDA backend
-#$CMAKE_COMMAND \
-#  -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
-#  -D CMAKE_CXX_STANDARD:STRING="17" \
-#  -D CMAKE_CXX_COMPILER=g++ \
-#  -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos-kernels_install_cuda \
-#  -D BUILD_SHARED_LIBS:BOOL=OFF \
-#  \
-#  -D Kokkos_ROOT=$DEPS_ROOT/kokkos_install_cuda \
-#  \
-#  -D KokkosKernels_ENABLE_TPL_BLAS=ON \
-#  -D KokkosKernels_ENABLE_TPL_LAPACK=ON \
-#  -D KokkosKernels_ENABLE_TPL_CUSOLVER=ON \
-#  \
-#  -D Kokkos_ENABLE_SERIAL=ON \
-#  -D Kokkos_ENABLE_CUDA=ON \
-#  \
-#  ../kokkos-kernels
-#make -j${NPROCS} install
+$CMAKE_COMMAND \
+  -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
+  -D CMAKE_CXX_STANDARD:STRING="20" \
+  -D CMAKE_CXX_COMPILER=g++ \
+  -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos-kernels_install_cuda \
+  -D BUILD_SHARED_LIBS:BOOL=OFF \
+  \
+  -D Kokkos_ROOT=$DEPS_ROOT/kokkos_install_cuda \
+  \
+  -D KokkosKernels_ENABLE_TPL_BLAS=ON \
+  -D KokkosKernels_ENABLE_TPL_LAPACK=ON \
+  -D KokkosKernels_ENABLE_TPL_CUSOLVER=ON \
+  \
+  -D Kokkos_ENABLE_SERIAL=ON \
+  -D Kokkos_ENABLE_CUDA=ON \
+  \
+../kokkos-kernels
+make -j${NPROCS} install
+
+# Clean build dir
+rm -rf *
 
 cd .. && rm -rf kokkos-kernels kokkos-kernels_build

--- a/dependencies/kokkos/install.sh
+++ b/dependencies/kokkos/install.sh
@@ -24,14 +24,14 @@ cd .. && mkdir kokkos_build && cd kokkos_build
 # Build and install with Serial backend
 $CMAKE_COMMAND \
   -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
-  -D CMAKE_CXX_STANDARD:STRING="17" \
+  -D CMAKE_CXX_STANDARD:STRING="20" \
   -D CMAKE_CXX_COMPILER=g++ \
   -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos_install_serial \
   -D BUILD_SHARED_LIBS:BOOL=OFF \
   \
   -D Kokkos_ENABLE_SERIAL=ON \
   \
-  ../kokkos
+../kokkos
 make -j${NPROCS} install
 
 # Clean build dir
@@ -40,32 +40,37 @@ rm -rf *
 # Build and install with OpenMP backend
 $CMAKE_COMMAND \
   -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
-  -D CMAKE_CXX_STANDARD:STRING="17" \
+  -D CMAKE_CXX_STANDARD:STRING="20" \
   -D CMAKE_CXX_COMPILER=g++ \
   -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos_install_openmp \
   -D BUILD_SHARED_LIBS:BOOL=OFF \
   \
   -D Kokkos_ENABLE_OPENMP=ON \
   \
-  ../kokkos
+../kokkos
 make -j${NPROCS} install
 
 # Clean build dir
 rm -rf *
 
 # Build and install with Serial+CUDA backend
-#$CMAKE_COMMAND \
-#  -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
-#  -D CMAKE_CXX_STANDARD:STRING="17" \
-#  -D CMAKE_CXX_COMPILER=g++ \
-#  -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos_install_cuda \
-#  -D BUILD_SHARED_LIBS:BOOL=OFF \
-#  \
-#  -D Kokkos_ENABLE_SERIAL=ON \
-#  -D Kokkos_ENABLE_CUDA=ON \
-#  \
-#  ../kokkos
-#make -j${NPROCS} install
+$CMAKE_COMMAND \
+  -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
+  -D CMAKE_CXX_STANDARD:STRING="20" \
+  -D CMAKE_CXX_COMPILER=g++ \
+  -D CMAKE_INSTALL_PREFIX:STRING=$DEPS_ROOT/kokkos_install_cuda \
+  -D BUILD_SHARED_LIBS:BOOL=OFF \
+  \
+  -D Kokkos_ENABLE_SERIAL=ON \
+  -D Kokkos_ENABLE_CUDA=ON \
+  \
+  -D Kokkos_ARCH_HOPPER90=ON \
+  \
+../kokkos
+make -j${NPROCS} install
+
+# Clean build dir
+rm -rf *
 
 # keep kokkos (src) for nvcc_wrapper
 cd .. && rm -rf kokkos_build

--- a/docker/dependencies/Dockerfile
+++ b/docker/dependencies/Dockerfile
@@ -27,8 +27,14 @@ RUN apt-get update && apt-get install -y \
       unzip \
       vim \
       wget \
+      gfortran \
+      ca-certificates \
+      clang \
       && \
-    apt-get update && apt-get install -y \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb && \
+    dpkg -i cuda-keyring_1.1-1_all.deb && \
+    rm cuda-keyring_1.1-1_all.deb && \
+    apt-get update && apt-get install -y --no-install-recommends \
       libblas-dev \
       libboost-all-dev \
       libcln-dev \
@@ -44,6 +50,16 @@ RUN apt-get update && apt-get install -y \
       ninja-build \
       libomp-dev \
       libvtk9-dev \
+      cuda-nvcc-12-8 \
+      cuda-cudart-dev-12-8 \
+      cuda-driver-dev-12-8 \
+      libcublas-dev-12-8 \
+      libcusolver-dev-12-8 \
+      libcusparse-dev-12-8 \
+      libcurand-dev-12-8 \
+      libnvjitlink-12-8 \
+      libnvjitlink-dev-12-8 \
+      cuda-nvtx-12-8 \
   && rm -rf /var/lib/apt/lists/*
 
 # Create directory for dependencies
@@ -53,6 +69,9 @@ ENV NPROCS=$NPROCS \
 RUN mkdir -p ${DEPS_ROOT}
 
 COPY dependencies /dependencies
+
+# Make `nvcc` available as an environment variable
+ENV PATH=/usr/local/cuda/bin:${PATH}
 
 # Install Kokkos and Kokkos-Kernels
 RUN /dependencies/kokkos/install.sh ${DEPS_ROOT}

--- a/src/mirco_evaluate.cpp
+++ b/src/mirco_evaluate.cpp
@@ -100,7 +100,8 @@ namespace MIRCO
       // Compute error due to nonlinear correction
       if (k > 0)
       {
-        deltaTotalForce = std::abs(totalForceVector[k] - totalForceVector[k - 1]) / totalForceVector[k];
+        deltaTotalForce =
+            std::abs(totalForceVector[k] - totalForceVector[k - 1]) / totalForceVector[k];
       }
 
       ++k;

--- a/src/mirco_exportvisualization.cpp
+++ b/src/mirco_exportvisualization.cpp
@@ -1,16 +1,6 @@
 #include "mirco_exportvisualization.h"
 
-#include <vtkFloatArray.h>
-#include <vtkImageData.h>
-#include <vtkNew.h>
-#include <vtkPointData.h>
-#include <vtkUnsignedCharArray.h>
-#include <vtkXMLImageDataWriter.h>
-#include <vtkZLibDataCompressor.h>
-
-#include <cstring>  // for memset
-#include <string>
-#include <vector>
+#include "mirco_exportvisualization_vtk.h"
 
 namespace MIRCO
 {
@@ -20,59 +10,26 @@ namespace MIRCO
     const int n = otherFields[0].extent(0);
     const int n2 = n * n;
 
-    vtkNew<vtkImageData> img;
-    img->SetDimensions(n, n, 1);
-    img->SetSpacing(gridSize, gridSize, 1.0);
-    img->SetOrigin(0.0, 0.0, 0.0);
+    ViewVectorInt_h activeSet_h =
+        Kokkos::create_mirror_view_and_copy(ExecSpace_DefaultHost_t(), activeSet);
 
-    // Active set
-    {
-      ViewVectorInt_h activeSet_h =
-          Kokkos::create_mirror_view_and_copy(ExecSpace_DefaultHost_t(), activeSet);
+    std::vector<unsigned char> activeSetPlain(n2, 0);
 
-      vtkNew<vtkUnsignedCharArray> vtkArr;
-      vtkArr->SetName("Active Set");
-      vtkArr->SetNumberOfComponents(1);
-      vtkArr->SetNumberOfTuples(n2);
+    for (int indA = 0; indA < activeSet_h.extent(0); ++indA) activeSetPlain[activeSet_h(indA)] = 1;
 
-      auto* vtkArrArr = static_cast<unsigned char*>(vtkArr->WriteVoidPointer(0, n2));
-      std::memset(vtkArrArr, 0, static_cast<size_t>(n2));
+    std::vector<std::vector<float>> fieldsPlain(otherFields.size());
 
-      for (int indA = 0; indA < activeSet_h.extent(0); ++indA)
-        vtkArr->SetValue(activeSet_h(indA), 1);
-
-      img->GetPointData()->AddArray(vtkArr);
-    }
-
-    // Other fields
     for (int f = 0; f < otherFields.size(); ++f)
     {
       ViewMatrix_h field_h =
           Kokkos::create_mirror_view_and_copy(ExecSpace_DefaultHost_t(), otherFields[f]);
 
-      vtkNew<vtkFloatArray> vtkArr;
-      vtkArr->SetName(otherFieldNames[f].c_str());
-      vtkArr->SetNumberOfComponents(1);
-      vtkArr->SetNumberOfTuples(n2);
+      fieldsPlain[f].resize(n2);
 
       for (int i = 0; i < n; ++i)
-        for (int j = 0; j < n; ++j) vtkArr->SetValue(i + n * j, field_h(i, j));
-
-      img->GetPointData()->AddArray(vtkArr);
+        for (int j = 0; j < n; ++j) fieldsPlain[f][i + n * j] = static_cast<float>(field_h(i, j));
     }
 
-    vtkNew<vtkXMLImageDataWriter> w;
-    w->SetFileName((path + ".vti").c_str());
-    w->SetInputData(img);
-
-    vtkNew<vtkZLibDataCompressor> z;
-    w->SetCompressor(z);
-    w->SetDataModeToAppended();
-    w->EncodeAppendedDataOff();
-
-    if (!w->Write())
-    {
-      std::cerr << "WARNING: ExportVisualization() failed to write to file\n\n";
-    }
+    ExportVisualizationVTK(path, gridSize, n, activeSetPlain, fieldsPlain, otherFieldNames);
   }
 }  // namespace MIRCO

--- a/src/mirco_exportvisualization.h
+++ b/src/mirco_exportvisualization.h
@@ -2,6 +2,7 @@
 #define SRC_EXPORTVISUALIZATION_H_
 
 #include <string>
+#include <vector>
 
 #include "mirco_kokkostypes.h"
 

--- a/src/mirco_exportvisualization_vtk.cpp
+++ b/src/mirco_exportvisualization_vtk.cpp
@@ -1,0 +1,64 @@
+#include "mirco_exportvisualization_vtk.h"
+
+#include <vtkFloatArray.h>
+#include <vtkImageData.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
+#include <vtkUnsignedCharArray.h>
+#include <vtkXMLImageDataWriter.h>
+#include <vtkZLibDataCompressor.h>
+
+#include <iostream>
+
+namespace MIRCO
+{
+  void ExportVisualizationVTK(const std::string& path, float gridSize, int n,
+      const std::vector<unsigned char>& activeSet,
+      const std::vector<std::vector<float>>& otherFields,
+      const std::vector<std::string>& otherFieldNames)
+  {
+    const int n2 = n * n;
+
+    vtkNew<vtkImageData> img;
+    img->SetDimensions(n, n, 1);
+    img->SetSpacing(gridSize, gridSize, 1.0);
+    img->SetOrigin(0.0, 0.0, 0.0);
+
+    // Active set
+    {
+      vtkNew<vtkUnsignedCharArray> vtkArr;
+      vtkArr->SetName("Active Set");
+      vtkArr->SetNumberOfComponents(1);
+      vtkArr->SetNumberOfTuples(n2);
+
+      for (int i = 0; i < n2; ++i) vtkArr->SetValue(i, activeSet[i]);
+
+      img->GetPointData()->AddArray(vtkArr);
+    }
+
+    // Other fields
+    for (int f = 0; f < otherFields.size(); ++f)
+    {
+      vtkNew<vtkFloatArray> vtkArr;
+      vtkArr->SetName(otherFieldNames[f].c_str());
+      vtkArr->SetNumberOfComponents(1);
+      vtkArr->SetNumberOfTuples(n2);
+
+      for (int i = 0; i < n2; ++i) vtkArr->SetValue(i, otherFields[f][i]);
+
+      img->GetPointData()->AddArray(vtkArr);
+    }
+
+    vtkNew<vtkXMLImageDataWriter> w;
+    w->SetFileName((path + ".vti").c_str());
+    w->SetInputData(img);
+
+    vtkNew<vtkZLibDataCompressor> z;
+    w->SetCompressor(z);
+    w->SetDataModeToAppended();
+    w->EncodeAppendedDataOff();
+
+    if (!w->Write()) std::cerr << "WARNING: ExportVisualization() failed to write to file\n\n";
+  }
+
+}  // namespace MIRCO

--- a/src/mirco_exportvisualization_vtk.h
+++ b/src/mirco_exportvisualization_vtk.h
@@ -1,0 +1,15 @@
+#ifndef SRC_EXPORTVISUALIZATIONVTK_H_
+#define SRC_EXPORTVISUALIZATIONVTK_H_
+
+#include <string>
+#include <vector>
+
+namespace MIRCO
+{
+  void ExportVisualizationVTK(const std::string& path, float gridSize, int n,
+      const std::vector<unsigned char>& activeSet,
+      const std::vector<std::vector<float>>& otherFields,
+      const std::vector<std::string>& otherFieldNames);
+}  // namespace MIRCO
+
+#endif  // SRC_EXPORTVISUALIZATIONVTK_H_

--- a/src/mirco_matrixsetup.cpp
+++ b/src/mirco_matrixsetup.cpp
@@ -61,47 +61,4 @@ namespace MIRCO
     return H;
   }
 
-  double SetupMatrixOneEntry(const int ix, const int iy, const int jx, const int jy,
-      const double GridSize, const double CompositeYoungs, const int N,
-      const bool PressureGreenFunFlag)
-  {
-    constexpr double pi = M_PI;
-    const double frac_GridSize_2 = GridSize / 2;
-
-    const double xi = ix * GridSize;
-    const double yi = iy * GridSize;
-    const double xj = jx * GridSize;
-    const double yj = jy * GridSize;
-
-    if (PressureGreenFunFlag)
-    {
-      const double k = xi - xj + frac_GridSize_2;
-      const double l = k - GridSize;
-      const double m = yi - yj + frac_GridSize_2;
-      const double n = m - GridSize;
-
-      return 1.0 / (pi * CompositeYoungs) *
-             (k * log((sqrt(k * k + m * m) + m) / (sqrt(k * k + n * n) + n)) +
-                 l * log((sqrt(l * l + n * n) + n) / (sqrt(l * l + m * m) + m)) +
-                 m * log((sqrt(m * m + k * k) + k) / (sqrt(m * m + l * l) + l)) +
-                 n * log((sqrt(n * n + l * l) + l) / (sqrt(n * n + k * k) + k)));
-    }
-
-    else
-    {
-      const double C = 1 / (CompositeYoungs * pi * frac_GridSize_2);
-
-      if (ix == jx && iy == jy)
-        return C;
-
-      else
-      {
-        const double tmp1 = xj - xi;
-        const double tmp2 = yj - yi;
-        const double r = sqrt(tmp1 * tmp1 + tmp2 * tmp2);
-        return C * asin(frac_GridSize_2 / r);
-      }
-    }
-  }
-
 }  // namespace MIRCO

--- a/src/mirco_matrixsetup.h
+++ b/src/mirco_matrixsetup.h
@@ -37,9 +37,50 @@ namespace MIRCO
    *
    * @return Matrix entry of H
    */
+
+  KOKKOS_INLINE_FUNCTION
   double SetupMatrixOneEntry(const int ix, const int iy, const int jx, const int jy,
       const double GridSize, const double CompositeYoungs, const int N,
-      const bool PressureGreenFunFlag);
+      const bool PressureGreenFunFlag)
+  {
+    constexpr double pi = M_PI;
+    const double frac_GridSize_2 = GridSize / 2;
+
+    const double xi = ix * GridSize;
+    const double yi = iy * GridSize;
+    const double xj = jx * GridSize;
+    const double yj = jy * GridSize;
+
+    if (PressureGreenFunFlag)
+    {
+      const double k = xi - xj + frac_GridSize_2;
+      const double l = k - GridSize;
+      const double m = yi - yj + frac_GridSize_2;
+      const double n = m - GridSize;
+
+      return 1.0 / (pi * CompositeYoungs) *
+             (k * log((sqrt(k * k + m * m) + m) / (sqrt(k * k + n * n) + n)) +
+                 l * log((sqrt(l * l + n * n) + n) / (sqrt(l * l + m * m) + m)) +
+                 m * log((sqrt(m * m + k * k) + k) / (sqrt(m * m + l * l) + l)) +
+                 n * log((sqrt(n * n + l * l) + l) / (sqrt(n * n + k * k) + k)));
+    }
+
+    else
+    {
+      const double C = 1 / (CompositeYoungs * pi * frac_GridSize_2);
+
+      if (ix == jx && iy == jy)
+        return C;
+
+      else
+      {
+        const double tmp1 = xj - xi;
+        const double tmp2 = yj - yi;
+        const double r = sqrt(tmp1 * tmp1 + tmp2 * tmp2);
+        return C * asin(frac_GridSize_2 / r);
+      }
+    }
+  }
 }  // namespace MIRCO
 
 #endif  // SRC_MATRIXSETUP_H_


### PR DESCRIPTION
@mayrmt

## Description
<!--
Provide a brief and concise description of your proposed change. Why is this change required? What problem does it solve?
-->
This change allows one to use the `clangcuda++` wrapper as the `CXX_COMPILER`, rather than `nvcc_wrapper`, when building with CUDA backend enabled. The primary motivation is that this allows upstream projects like 4C to fetch MIRCO using FetchContent and to compile it correctly with CUDA backend enabled. An additional benefit is that no `MIRCO_HOST_COMPILER` needs to be specified in this case, because `clangcuda++` can compile things like ryml without issue. To achieve this split, the `MIRCO_CLANGCUDA` option is introduced, and when it is true, the relevant targets are marked with `CLANGCUDA_MODE_HOST` or `CLANGCUDA_MODE_DEVICE`.

### Build tests
Additionally, build tests were setup for Kokkos with CUDA backend, both with the `nvcc_wrapper` and `clangcuda++` as the compiler. This required adding the relevant cuda-related apt-get items to the Dockerfile, which leads to a significantly larger Docker image (3,0GiB -> 7,8GiB)

Making the build test for the variant using `clangcuda++` required this wrapper to be available, so I have added it into MIRCO's source. This does of course pose the problem that MIRCO and 4C will both have this wrapper. I could remove it from 4C to prevent this redundancy, and then just clone the small MIRCO repository to make `clangcuda++` available for the build tests in 4C.

### Visualization Export
I also discovered while working on this that the visualization export functionality was not working while using Kokkos CUDA. I thought I tested it, but a small change was required. A larger change was required to make it work with `clangcuda++`, which is that I needed to split the visualization export into a TU that depends only on VTK and one that depends only on Kokkos. I decided to just make that conceptually simple change to make sure it always works.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests:
-->
* Precedes https://github.com/4C-multiphysics/4C/pull/2012
